### PR TITLE
Bust SwiftPM build caches to fix segfaulting release binary

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -114,7 +114,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .build/
-          key: ${{ runner.os }}-build-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-build-v2-${{ hashFiles('Package.resolved') }}
 
       - name: Configure Architecture Prefix
         run: |
@@ -144,7 +144,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .build/
-          key: ${{ runner.os }}-release-${{ hashFiles('Package.resolved', 'Sources/**/*.swift') }}
+          key: ${{ runner.os }}-release-v2-${{ hashFiles('Package.resolved', 'Sources/**/*.swift') }}
 
       - name: Build Release Product
         run: |


### PR DESCRIPTION
## Summary
- Bumps the `build-linux` and `package-linux` cache keys to `-v2-` so the poisoned `.build/` from the 2026-06-03 run is no longer restored
- Fixes the immediate `Segmentation fault (core dumped)` in the deploy step of [run 27016087316](https://github.com/brightdigit/brightdigit.com/actions/runs/27016087316/job/79732462092)
- Tracks the durable fix (pin the `brightdigit/publish-xml` image or fold its digest into the cache key) in #65

## Test plan
- [ ] CI on this PR runs a clean release build (cache miss expected on `Linux-release-v2-...`)
- [ ] After merge, the deploy job on `main` produces a working `brightdigitwg-Linux-x86_64` binary and Netlify deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline cache configuration to improve build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->