### PR TITLE
Fast-deploy: cache prebuilt binary for content-only commits (#68)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,6 +21,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code-changed: ${{ steps.filter.outputs.code }}
+      image-digest: ${{ steps.image.outputs.digest }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect code changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # Anything that affects the compiled binary or the CI logic itself.
+          # Content/ markdown is runtime data and is intentionally excluded.
+          filters: |
+            code:
+              - 'Sources/**'
+              - 'Package.swift'
+              - 'Package.resolved'
+              - '.swift-version'
+              - 'Dockerfile'
+              - '.github/workflows/main.yaml'
+
+      - name: Resolve build image digest
+        id: image
+        run: |
+          DIGEST=$(docker buildx imagetools inspect brightdigit/publish-xml:6.4 \
+            --format '{{.Manifest.Digest}}')
+          echo "Resolved brightdigit/publish-xml:6.4 -> ${DIGEST}"
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
   automate-content:
       if: ${{ inputs.automate_content != '' }}
       runs-on: [self-hosted, macOS]
@@ -103,6 +137,8 @@ jobs:
                 fi
 
   build-linux:
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.code-changed == 'true' }}
     runs-on: ubuntu-latest
     container:
       image: brightdigit/publish-xml:6.4
@@ -122,7 +158,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .build/
-          key: ${{ runner.os }}-build-${{ steps.swift.outputs.ver }}-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-build-${{ steps.swift.outputs.ver }}-${{ needs.detect-changes.outputs.image-digest }}-${{ hashFiles('Package.resolved') }}
 
       - name: Configure Architecture Prefix
         run: |
@@ -136,7 +172,10 @@ jobs:
         run: swift test
   
   package-linux:
-    needs: build-linux
+    needs: [detect-changes, build-linux]
+    # build-linux is skipped on content-only commits; still run as long as it
+    # didn't actually fail (success or skipped both proceed).
+    if: ${{ !cancelled() && needs.build-linux.result != 'failure' }}
     runs-on: ubuntu-latest
     container:
       image: brightdigit/publish-xml:6.4
@@ -156,9 +195,21 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .build/
-          key: ${{ runner.os }}-release-${{ steps.swift.outputs.ver }}-${{ hashFiles('Package.resolved', 'Sources/**/*.swift') }}
+          key: ${{ runner.os }}-release-${{ steps.swift.outputs.ver }}-${{ needs.detect-changes.outputs.image-digest }}-${{ hashFiles('Package.resolved', 'Sources/**/*.swift') }}
+
+      # Cache the prebuilt release binary keyed on Swift source state AND the build
+      # image digest. The digest is essential: keying on source alone deployed an
+      # ABI-incompatible binary when the image drifted (issue #65 segfault). A
+      # content-only commit hits this cache and skips the release build entirely.
+      - name: Cache Release Binary
+        id: bincache
+        uses: actions/cache@v4
+        with:
+          path: brightdigitwg-Linux-x86_64
+          key: bin-${{ runner.os }}-${{ steps.swift.outputs.ver }}-${{ needs.detect-changes.outputs.image-digest }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**/*.swift') }}
 
       - name: Build Release Product
+        if: ${{ steps.bincache.outputs.cache-hit != 'true' }}
         run: |
           swift build -c release --product brightdigitwg
           BIN_PATH=$(swift build -c release --product brightdigitwg --show-bin-path)


### PR DESCRIPTION
Closes #68.

## What

CI rebuilt the `brightdigitwg` binary on every push, even when only `Content/` markdown changed. Content is runtime data — not compiled into the binary — so content-only commits now skip the build and deploy straight from a cached prebuilt binary.

## Changes (`.github/workflows/main.yaml`)

- **New `detect-changes` job** (host runner) outputs:
  - `code-changed` — true when `Sources/**`, `Package.swift`, `Package.resolved`, `.swift-version`, `Dockerfile`, or the workflow file changed (via `dorny/paths-filter@v3`). Content-only commits → `false`.
  - `image-digest` — resolved digest of `brightdigit/publish-xml:6.4` (`docker buildx imagetools inspect`).
- **`build-linux`** gated on `code-changed`, so the debug build + tests are skipped on content-only commits.
- **`package-linux`**:
  - Caches the release binary keyed on `runner.os` + Swift version + **image digest** + `hashFiles(Package.resolved, Package.swift, Sources/**/*.swift)`.
  - Build Release Product step skipped on cache hit; artifact upload unchanged so `deploy`'s contract is identical.
  - `if: !cancelled() && needs.build-linux.result != 'failure'` so it still runs when `build-linux` is skipped.
- **Both `.build/` cache keys** now fold in the image digest too.

## Why the image digest matters (issue #65)

A binary cache keyed on source state alone already caused a production segfault (#65): when the image drifted but sources didn't, a content-only commit got a cache hit and deployed an ABI-incompatible binary. Folding the digest into every cache key means an image re-push invalidates all cache layers and forces a rebuild — retiring that failure class rather than just mitigating it.

## Behavior

- **Content-only commit:** `build-linux` skipped, binary cache hit → no `swift build`, deploy from cache.
- **Swift/Package change:** full build + test + release build as before.
- **Image re-push:** digest changes → cache miss → rebuild against the new image.

## Verification

- `actionlint` passes (no structural/expression errors; only pre-existing shellcheck style infos in untouched steps).
- End-to-end CI paths (content-only skip vs source-change rebuild) verify on this PR's runs and a follow-up content-only commit.

## Follow-up

- #74 — move the `automate-content` job off self-hosted macOS to a Linux runner (can reuse this cached binary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline with improved change detection and caching strategies.
  * Enhanced build efficiency by making builds conditional on code changes and leveraging Docker image state for cache management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->