### PR TITLE
Fix build-linux nightly cache key via swift-build#110

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -151,7 +151,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Build and Test
-        uses: brightdigit/swift-build@v1
+        # TEMP: testing brightdigit/swift-build#110 (nightly cache-key fix, issue #79).
+        # Revert to @v1 once #110 merges and ships in a v1.x release.
+        uses: brightdigit/swift-build@109-invalidate-spm-caches
 
   lint:
     needs: [detect-changes, build-linux]


### PR DESCRIPTION
Closes #79.

## What

Points the `build-linux` job at the swift-build PR branch (`109-invalidate-spm-caches`) to test the upstream nightly cache-key fix ([brightdigit/swift-build#110](https://github.com/brightdigit/swift-build/pull/110)) before it ships in `v1`.

## Why

`build-linux` migrated to `brightdigit/swift-build@v1` in #76. The action's Ubuntu SPM cache key derives the Swift version from `swift --version | cut -d' ' -f3`, which collapses every 6.4 nightly snapshot to `6.4-dev`. When `publish-xml:6.4` is bumped, `build-linux` restores a stale `.build/` from the previous toolchain — the regression of the #65 segfault protection.

swift-build#110 takes an input-free approach: it parses the compiler commit out of the `swift --version` parenthetical and appends it to dev versions (`6.4-dev` → `6.4-dev-<commit>`), rotating the key per snapshot. Stable releases are unchanged.

## Verification

Check the `build-linux` SPM cache step in this run's logs — the key should now carry a commit-hash suffix (`spm-noble-6.4-dev-<commit>-…`) instead of bare `spm-noble-6.4-dev-…`, and build + tests should pass.

## Follow-up

Revert to `brightdigit/swift-build@v1` once #110 merges and ships in a `v1.x` release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow dependency to a newer version with improved cache handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->