### PR TITLE
Contribute: handle <dl> and layout <table> in SwiftSoupMarkdownGenerator (#94)

### DIFF
--- a/Packages/BrightDigit/Contribute/Sources/Contribute/SwiftSoupMarkdownGenerator+Markup.swift
+++ b/Packages/BrightDigit/Contribute/Sources/Contribute/SwiftSoupMarkdownGenerator+Markup.swift
@@ -45,7 +45,7 @@ extension SwiftSoupMarkdownGenerator {
   }
 
   /// Renders a single element as zero or more block-level nodes.
-  private func blockMarkup(for element: SwiftSoup.Element) throws -> [any BlockMarkup] {
+  internal func blockMarkup(for element: SwiftSoup.Element) throws -> [any BlockMarkup] {
     let tag = element.tagName()
     switch tag {
     case "h1", "h2", "h3", "h4", "h5", "h6":
@@ -81,7 +81,13 @@ extension SwiftSoupMarkdownGenerator {
       let inline = try inlineMarkup(for: element)
       return inline.isEmpty ? [] : [Paragraph(inline)]
 
-    case "script", "style", "iframe", "figure", "ins", "noscript", "dl", "table":
+    case "dl":
+      return try definitionList(from: element)
+
+    case "table":
+      return try tableBlocks(from: element)
+
+    case "script", "style", "iframe", "figure", "ins", "noscript":
       // Intentionally dropped (non-content or unsupported, see Known limitations).
       return []
 
@@ -148,7 +154,7 @@ extension SwiftSoupMarkdownGenerator {
 
   /// Renders the inline content of `element`, walking child text and inline
   /// elements recursively while skipping block-level children.
-  private func inlineChildren(
+  internal func inlineChildren(
     of element: SwiftSoup.Element
   ) throws -> [any InlineMarkup] {
     var result: [any InlineMarkup] = []

--- a/Packages/BrightDigit/Contribute/Sources/Contribute/SwiftSoupMarkdownGenerator+TableList.swift
+++ b/Packages/BrightDigit/Contribute/Sources/Contribute/SwiftSoupMarkdownGenerator+TableList.swift
@@ -1,0 +1,143 @@
+//
+//  SwiftSoupMarkdownGenerator+TableList.swift
+//  Contribute
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import Foundation
+import Markdown
+import SwiftSoup
+
+extension SwiftSoupMarkdownGenerator {
+  // MARK: - Definition lists
+
+  /// Renders a `<dl>` as a sequence of paragraphs: each `<dt>` becomes a
+  /// bold term, and each following `<dd>` contributes its own block content.
+  ///
+  /// swift-markdown has no definition-list node, so this mapping preserves the
+  /// term/definition pairing in plain CommonMark (a `**term**` paragraph
+  /// followed by the definition's blocks). It is intentionally lossy with
+  /// respect to the semantic `<dl>` structure but loses no textual content,
+  /// which the previously dropped behaviour did not guarantee.
+  internal func definitionList(from element: SwiftSoup.Element) throws -> [any BlockMarkup] {
+    var blocks: [any BlockMarkup] = []
+    for child in childElements(of: element) {
+      switch child.tagName() {
+      case "dt":
+        try term(of: child).map { blocks.append($0) }
+      case "dd":
+        blocks.append(contentsOf: try cellBlocks(of: child))
+      default:
+        break
+      }
+    }
+    return blocks
+  }
+
+  /// Renders a `<dt>` as a bold-term paragraph, or `nil` when it is empty.
+  ///
+  /// The term is only emboldened when every inline child can nest inside a
+  /// `Strong` (swift-markdown forbids `Link`/`Image` there). When it cannot —
+  /// e.g. a term that is itself a link — the inline content is emitted verbatim
+  /// so that no content is lost.
+  private func term(of element: SwiftSoup.Element) throws -> Paragraph? {
+    let inline = try inlineChildren(of: element)
+    guard !inline.isEmpty else {
+      return nil
+    }
+    let recurring = inline.compactMap { $0 as? any RecurringInlineMarkup }
+    if recurring.count == inline.count {
+      return Paragraph([Strong(recurring)])
+    }
+    return Paragraph(inline)
+  }
+
+  // MARK: - Tables
+
+  /// Renders a `<table>` by extracting the block content of every cell in
+  /// document order.
+  ///
+  /// Our real imported content (notably Mailchimp newsletters) uses tables
+  /// purely for layout, with no header rows, so emitting a GFM data table
+  /// would produce malformed output. Flattening cell content preserves the
+  /// body — which the previously dropped behaviour discarded entirely — while
+  /// staying valid CommonMark. Genuine data tables (with `<th>`) are not part
+  /// of our content and are not specially handled.
+  internal func tableBlocks(from element: SwiftSoup.Element) throws -> [any BlockMarkup] {
+    var blocks: [any BlockMarkup] = []
+    for cell in ownCells(of: element) {
+      blocks.append(contentsOf: try cellBlocks(of: cell))
+    }
+    return blocks
+  }
+
+  /// The `<td>`/`<th>` cells belonging directly to `table` (not to any nested
+  /// table), in document order. Nested tables are reached through
+  /// ``cellBlocks(of:)`` recursion, so collecting all descendant cells here
+  /// would emit nested content twice.
+  private func ownCells(of table: SwiftSoup.Element) -> [SwiftSoup.Element] {
+    var cells: [SwiftSoup.Element] = []
+    for row in rows(of: table) {
+      for cell in childElements(of: row)
+      where cell.tagName() == "td" || cell.tagName() == "th" {
+        cells.append(cell)
+      }
+    }
+    return cells
+  }
+
+  /// The `<tr>` rows belonging directly to `table`, descending through an
+  /// optional `<thead>`/`<tbody>`/`<tfoot>` wrapper but not into nested tables.
+  private func rows(of table: SwiftSoup.Element) -> [SwiftSoup.Element] {
+    var rows: [SwiftSoup.Element] = []
+    for child in childElements(of: table) {
+      switch child.tagName() {
+      case "tr":
+        rows.append(child)
+      case "thead", "tbody", "tfoot":
+        rows.append(contentsOf: childElements(of: child, named: "tr"))
+      default:
+        break
+      }
+    }
+    return rows
+  }
+
+  /// Renders the content of a container cell (`<dd>`, `<td>`, `<th>`):
+  /// leading inline content as a paragraph, then any nested block children.
+  private func cellBlocks(of element: SwiftSoup.Element) throws -> [any BlockMarkup] {
+    var blocks: [any BlockMarkup] = []
+    let inline = try inlineChildren(of: element)
+    if !inline.isEmpty {
+      blocks.append(Paragraph(inline))
+    }
+    for child in childElements(of: element)
+    where Self.blockLevelTags.contains(child.tagName()) {
+      blocks.append(contentsOf: try blockMarkup(for: child))
+    }
+    return blocks
+  }
+}

--- a/Packages/BrightDigit/Contribute/Sources/Contribute/SwiftSoupMarkdownGenerator.swift
+++ b/Packages/BrightDigit/Contribute/Sources/Contribute/SwiftSoupMarkdownGenerator.swift
@@ -38,11 +38,25 @@ import SwiftSoup
 /// Unlike `PandocMarkdownGenerator` (removed), this requires no external
 /// `pandoc` binary, making it portable across Linux and CI environments.
 ///
-/// ## Known limitations
+/// ## Coverage
 /// The converter targets the common subset of post HTML (headings, paragraphs,
-/// inline emphasis/links/code, lists, block quotes, images, code blocks). It
-/// does **not** handle `<dl>`/`<dt>`/`<dd>`, `<table>`, or arbitrarily deep
-/// mixed block nesting, and does not aim for full Pandoc parity.
+/// inline emphasis/links/code, lists, block quotes, images, code blocks).
+///
+/// `<dl>`/`<dt>`/`<dd>` and `<table>` are also handled, but lossily, because
+/// CommonMark/swift-markdown have no node for either:
+/// - A `<dl>` renders each `<dt>` as a bold-term paragraph followed by its
+///   `<dd>` content, preserving the term/definition pairing as plain prose.
+/// - A `<table>` is treated as layout (our only real-world use, e.g. Mailchimp
+///   newsletters) and flattened to its cells' block content in document order.
+///   This deliberately does **not** emit a GFM data table; genuine
+///   `<th>`-headed data tables are not part of our content and are not
+///   specially handled.
+///
+/// ## Known limitations
+/// The converter does not aim for full Pandoc parity. It does not preserve
+/// semantic `<dl>`/`<table>` structure (see Coverage), does not emit GFM data
+/// tables, and `Link`/`Image` nested inside `<strong>`/`<em>`/`<a>` are dropped
+/// because swift-markdown's inline type model cannot represent them.
 ///
 /// Block and inline rendering lives in `SwiftSoupMarkdownGenerator+Markup.swift`.
 public struct SwiftSoupMarkdownGenerator: MarkdownGenerator {

--- a/Packages/BrightDigit/Contribute/Tests/ContributeTests/SwiftSoupMarkdownGeneratorTests.swift
+++ b/Packages/BrightDigit/Contribute/Tests/ContributeTests/SwiftSoupMarkdownGeneratorTests.swift
@@ -89,6 +89,91 @@ internal final class SwiftSoupMarkdownGeneratorTests: XCTestCase {
     XCTAssertFalse(markdown.contains("```swift"), markdown)
   }
 
+  // MARK: Definition lists
+
+  internal func testDefinitionListRendersTermsAndDefinitions() throws {
+    let html = """
+      <dl>
+        <dt>package.json</dt>
+        <dd>for what node modules need to be installed</dd>
+        <dt>Gruntfile.js</dt>
+        <dd>the "make" file</dd>
+      </dl>
+      """
+    let markdown = try sut.markdown(fromHTML: html)
+    // Regression: <dl> used to be dropped entirely, losing all content.
+    XCTAssertTrue(markdown.contains("**package.json**"), markdown)
+    XCTAssertTrue(markdown.contains("for what node modules need to be installed"), markdown)
+    XCTAssertTrue(markdown.contains("**Gruntfile.js**"), markdown)
+    XCTAssertTrue(markdown.contains("the \"make\" file"), markdown)
+  }
+
+  internal func testDefinitionListPreservesInlineFormattingInTerm() throws {
+    let html = """
+      <dl>
+        <dt><a href="http://nodejs.org/">NodeJS</a></dt>
+        <dd>for building the project</dd>
+      </dl>
+      """
+    let markdown = try sut.markdown(fromHTML: html)
+    XCTAssertTrue(markdown.contains("[NodeJS](http://nodejs.org/)"), markdown)
+    XCTAssertTrue(markdown.contains("for building the project"), markdown)
+  }
+
+  internal func testDefinitionListPreservesNestedBlockInDefinition() throws {
+    let html = """
+      <dl>
+        <dt>Grunt</dt>
+        <dd>install grunt globally
+          <pre><code class="language-bash">npm -g install grunt</code></pre>
+        </dd>
+      </dl>
+      """
+    let markdown = try sut.markdown(fromHTML: html)
+    XCTAssertTrue(markdown.contains("**Grunt**"), markdown)
+    XCTAssertTrue(markdown.contains("install grunt globally"), markdown)
+    // The nested code block inside the <dd> must survive.
+    XCTAssertTrue(markdown.contains("npm -g install grunt"), markdown)
+    XCTAssertTrue(markdown.contains("```bash"), markdown)
+  }
+
+  // MARK: Tables
+
+  internal func testLayoutTableFlattensCellContent() throws {
+    // Mailchimp newsletters wrap nearly all body content in layout tables.
+    let html = """
+      <table><tbody>
+        <tr><td><p>First cell</p></td></tr>
+        <tr><td><p>Second cell</p></td></tr>
+      </tbody></table>
+      """
+    let markdown = try sut.markdown(fromHTML: html)
+    // Regression: <table> used to be dropped, erasing the whole newsletter body.
+    XCTAssertTrue(markdown.contains("First cell"), markdown)
+    XCTAssertTrue(markdown.contains("Second cell"), markdown)
+  }
+
+  internal func testTablePreservesInlineFormattingAndLinks() throws {
+    let html = """
+      <table><tr><td><p>see <a href="https://example.com">the docs</a></p></td></tr></table>
+      """
+    let markdown = try sut.markdown(fromHTML: html)
+    XCTAssertTrue(markdown.contains("[the docs](https://example.com)"), markdown)
+  }
+
+  internal func testNestedTableContentEmittedExactlyOnce() throws {
+    let html = """
+      <table><tr><td>
+        <table><tr><td><p>inner only</p></td></tr></table>
+      </td></tr></table>
+      """
+    let markdown = try sut.markdown(fromHTML: html)
+    let occurrences = markdown.components(separatedBy: "inner only").count - 1
+    // Regression guard: descendant-cell selection must not double-emit nested
+    // table content.
+    XCTAssertEqual(occurrences, 1, markdown)
+  }
+
   // MARK: Stripped / empty content
 
   internal func testScriptAndIframeAreStripped() throws {


### PR DESCRIPTION
## Summary

Closes #94. Spot-checked the real import sources against the gaps documented in `SwiftSoupMarkdownGenerator` and closed the two that **actually occur** in our content.

### Real gaps found (and closed)
- **`<dl>`/`<dt>`/`<dd>`** — present in the real BrightDigit WordPress export (`Packages/BrightDigit/SyndiKit/Data/WordPress/articles.xml`, 3 occurrences). Previously dropped, losing all term/definition content.
- **`<table>`** — Mailchimp newsletters wrap **nearly all** body content in layout tables (no `<th>`). The old `<table>`-dropping behaviour erased essentially the entire newsletter body on re-import; the prior Pandoc pipeline preserved this content (as raw HTML in the `.md`).

### Theoretical gaps (left unhandled — no real content hits them)
- GFM **data tables** with `<th>` headers — our tables are layout-only. Emitting GFM for layout tables would be malformed, so we flatten instead.
- `<table>` content in third-party **RSS fixtures** (`SyndiKit Data/XML/*.xml`) — those feeds are SyndiKit's own test data, not part of our import pipeline.
- `Link`/`Image` nested inside `<strong>`/`<em>`/`<a>` — unchanged, documented limitation (swift-markdown's inline type model can't represent it).

## Implemented
Both conversions are content-preserving but intentionally lossy w.r.t. structure (swift-markdown has no node for either):
- `<dl>` → each `<dt>` rendered as a bold-term paragraph (emitted verbatim when it contains a link, which `Strong` can't nest), followed by each `<dd>`'s block content.
- `<table>` → cells' block content flattened in document order. Own-cell walk + recursion ensures nested-table content is emitted exactly once.
- Split table/definition-list rendering into `SwiftSoupMarkdownGenerator+TableList.swift` to stay under file-length lint limits.
- Updated the generator doc comment (Coverage + Known limitations).

## Tests
Added 6 regression tests in `SwiftSoupMarkdownGeneratorTests.swift`: definition-list terms/definitions, inline formatting in a `<dt>`, nested block (code block) inside a `<dd>`, layout-table cell flattening, links inside table cells, and a guard that nested-table content is emitted exactly once.

## Verification
- **Docker Ubuntu (Linux, swift 6.4)**: `swift build && swift test` → `EXIT=0` (both build and test complete). Run with reduced parallelism after the full-parallel run OOMed under QEMU x86 emulation on this arm64 host — a resource limit, not a code issue.
- **Contribute package (macOS, Swift 6.4 toolchain)**: `swift build && swift test` → **45 tests, 0 failures** (includes the 6 new tests).
- **STRICT lint** (`LINT_MODE=STRICT CI=true ./Scripts/lint.sh`): root → "Linting completed successfully"; Contribute → "0 violations, 0 serious in 54 files".

Note: the Contribute package depends on SwiftSoup via a relative monorepo path, so it isn't independently Docker-buildable; its tests are not in the root test target. The Linux Docker build compiles the Contribute sources cleanly as part of the full workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)