### PR TITLE
import podcast: match RSS↔YouTube by video id (title fallback)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -120,6 +120,13 @@ let package = Package(
         "Yams",
         "BrightDigitSite"
       ]
+    ),
+    .testTarget(
+      name: "BrightDigitArgsTests",
+      dependencies: [
+        "BrightDigitArgs",
+        "BrightDigitPodcast"
+      ]
     )
   ]
 )

--- a/Sources/BrightDigitArgs/Config/Import.PodcastCommand.swift
+++ b/Sources/BrightDigitArgs/Config/Import.PodcastCommand.swift
@@ -75,16 +75,67 @@ extension Import.PodcastCommand {
     )
   }
 
+  private static let youtubeIDRegex: NSRegularExpression = {
+    do {
+      return try NSRegularExpression(
+        pattern:
+          #"(?:youtube\.com/watch\?v=|youtu\.be/|youtube\.com/embed/)([A-Za-z0-9_-]{11})"#,
+        options: []
+      )
+    } catch {
+      preconditionFailure("Invalid youtubeIDRegex pattern: \(error)")
+    }
+  }()
+
+  /// Extracts YouTube video ids (in order, de-duplicated) from show-notes HTML.
+  ///
+  /// The RSS episode body embeds the episode's `…/watch?v=<id>` link, which is a
+  /// more reliable join key than the title (RSS and YouTube titles can differ —
+  /// e.g. `Peter Witham` vs `@PeterWitham`).
+  internal static func youtubeIDs(in html: String) -> [String] {
+    let range = NSRange(html.startIndex..., in: html)
+    var ids: [String] = []
+    for match in youtubeIDRegex.matches(in: html, options: [], range: range) {
+      guard let captured = Range(match.range(at: 1), in: html) else {
+        continue
+      }
+      let id = String(html[captured])
+      if !ids.contains(id) {
+        ids.append(id)
+      }
+    }
+    return ids
+  }
+
   internal static func episodesBasedOn(
     rssItems: [RSSContent.Source],
-    withVideoDurations videoDurations: VideoDurations
+    videoDurations: VideoDurations,
+    videosByID: VideoDurations
   ) throws -> [BrightDigitPodcastSource] {
     try BrightDigitPodcastSource
       .episodesBasedOn(
         rssItems: rssItems
       ) { rssItem in
+        // Prefer matching by the YouTube video id embedded in the show-notes.
+        for id in youtubeIDs(in: rssItem.content) where videosByID[id] != nil {
+          return videosByID[id]
+        }
+        // Fall back to an exact-title match.
         let title = rssItem.title.trimmingCharacters(in: .whitespacesAndNewlines)
-        return videoDurations[title]
+        if let video = videoDurations[title] {
+          return video
+        }
+        // No video at all — warn and skip rather than aborting the whole import.
+        FileHandle.standardError.write(
+          Data(
+            """
+            ⚠️  import podcast: no YouTube video for episode \
+            \(rssItem.episodeNo) “\(rssItem.title)” — skipping
+
+            """.utf8
+          )
+        )
+        return nil
       }
   }
 
@@ -106,11 +157,16 @@ extension Import.PodcastCommand {
       )
     )
     let videoDurations = try YouTubeContent.videoDurations(videos)
+    let videosByID = Dictionary(
+      videos.map { ($0.youtubeID, $0) },
+      uniquingKeysWith: { first, _ in first }
+    )
 
     let episodes: [BrightDigitPodcastSource] =
       try Self.episodesBasedOn(
         rssItems: podcastEpisodes,
-        withVideoDurations: videoDurations
+        videoDurations: videoDurations,
+        videosByID: videosByID
       )
       .sorted(by: { lhs, rhs in lhs.episodeNo < rhs.episodeNo })
 

--- a/Sources/BrightDigitArgs/Config/Import.PodcastCommand.swift
+++ b/Sources/BrightDigitArgs/Config/Import.PodcastCommand.swift
@@ -79,7 +79,8 @@ extension Import.PodcastCommand {
     do {
       return try NSRegularExpression(
         pattern:
-          #"(?:youtube\.com/watch\?v=|youtu\.be/|youtube\.com/embed/)([A-Za-z0-9_-]{11})"#,
+          #"(?:youtube\.com/watch\?v=|youtu\.be/|youtube\.com/embed/)"#
+          + #"([A-Za-z0-9_-]{11})"#,
         options: []
       )
     } catch {

--- a/Sources/BrightDigitArgs/Config/Import.PodcastCommand.swift
+++ b/Sources/BrightDigitArgs/Config/Import.PodcastCommand.swift
@@ -139,17 +139,9 @@ extension Import.PodcastCommand {
       }
   }
 
-  public func execute() async throws {
-    let contentPathURL = URL(fileURLWithPath: config.exportMarkdownDirectory)
-
-    let podcastEpisodes = try RSSContent.items(from: config.rss) { item in
-      guard let link = item.link else {
-        throw RSSError.missingFieldFromPodcastEpisode(
-          String(describing: item), .link
-        )
-      }
-      return link.lastPathComponent
-    }
+  private static func videoIndices(
+    config: Config
+  ) async throws -> (durations: VideoDurations, byID: VideoDurations) {
     let videos = try await YouTubeContent.videos(
       byRequest: .init(
         apiKey: config.youtubeAPIKey,
@@ -161,6 +153,21 @@ extension Import.PodcastCommand {
       videos.map { ($0.youtubeID, $0) },
       uniquingKeysWith: { first, _ in first }
     )
+    return (videoDurations, videosByID)
+  }
+
+  public func execute() async throws {
+    let contentPathURL = URL(fileURLWithPath: config.exportMarkdownDirectory)
+
+    let podcastEpisodes = try RSSContent.items(from: config.rss) { item in
+      guard let link = item.link else {
+        throw RSSError.missingFieldFromPodcastEpisode(
+          String(describing: item), .link
+        )
+      }
+      return link.lastPathComponent
+    }
+    let (videoDurations, videosByID) = try await Self.videoIndices(config: config)
 
     let episodes: [BrightDigitPodcastSource] =
       try Self.episodesBasedOn(

--- a/Sources/BrightDigitArgs/Config/Import.swift
+++ b/Sources/BrightDigitArgs/Config/Import.swift
@@ -7,7 +7,9 @@ import Contribute
 /// ``Import/MailchimpCommand``, ``Import/WordPressCommand``).
 public enum Import {
   /// The shared HTML-to-Markdown generator used by the Mailchimp and Podcast
-  /// importers. The podcast and Mailchimp importers convert source HTML to
+  /// importers.
+  ///
+  /// The podcast and Mailchimp importers convert source HTML to
   /// Markdown through this one ``Contribute/SwiftSoupMarkdownGenerator``.
   internal static let markdownGenerator = SwiftSoupMarkdownGenerator()
 }

--- a/Sources/BrightDigitPodcast/BrightDigitPodcast.Source.swift
+++ b/Sources/BrightDigitPodcast/BrightDigitPodcast.Source.swift
@@ -25,13 +25,17 @@ extension BrightDigitPodcast.Source {
     )
   }
 
+  /// Builds a podcast source for each RSS item that has a matching video.
+  ///
+  /// Items for which `fetchVideo` returns `nil` are skipped rather than fatal,
+  /// so one episode without a published video doesn't abort the whole import.
   public static func episodesBasedOn(
     rssItems: [AudioPodcastItem],
     fetchVideo: @escaping (AudioPodcastItem) -> VideoYouTubeItem?
   ) throws -> [BrightDigitPodcastSource] {
-    try rssItems.map { rssItem in
+    try rssItems.compactMap { rssItem in
       guard let video = fetchVideo(rssItem) else {
-        throw MediaError.missingVideoForEpisode(String(describing: rssItem))
+        return nil
       }
       return try .init(
         podcastID: rssItem.podcastID,

--- a/Sources/BrightDigitPodcast/MediaError.swift
+++ b/Sources/BrightDigitPodcast/MediaError.swift
@@ -1,7 +1,0 @@
-import Contribute
-import Foundation
-
-public enum MediaError: ContributeError {
-  case missingVideoForEpisode(String)
-  case invalidPodcastEpisodeFromRSSItem(String)
-}

--- a/Tests/BrightDigitArgsTests/PodcastMatchingTests.swift
+++ b/Tests/BrightDigitArgsTests/PodcastMatchingTests.swift
@@ -3,25 +3,25 @@ import Testing
 
 @testable import BrightDigitPodcast
 
-private struct StubAudio: AudioPodcastItem {
-  let podcastID = "pod"
-  let episodeNo: Int
-  let slug: String
-  let title: String
-  let date = Date(timeIntervalSince1970: 0)
-  let summary = ""
-  let content: String
-  let duration: TimeInterval = 100
-  let imageURL = URL(fileURLWithPath: "/image.png")
-  let audioURL = URL(fileURLWithPath: "/audio.mp3")
-}
-
-private struct StubVideo: VideoYouTubeItem {
-  let youtubeID: String
-  let duration: TimeInterval = 200
-}
-
 internal struct PodcastMatchingTests {
+  private struct StubAudio: AudioPodcastItem {
+    let podcastID = "pod"
+    let episodeNo: Int
+    let slug: String
+    let title: String
+    let date = Date(timeIntervalSince1970: 0)
+    let summary = ""
+    let content: String
+    let duration: TimeInterval = 100
+    let imageURL = URL(fileURLWithPath: "/image.png")
+    let audioURL = URL(fileURLWithPath: "/audio.mp3")
+  }
+
+  private struct StubVideo: VideoYouTubeItem {
+    let youtubeID: String
+    let duration: TimeInterval = 200
+  }
+
   /// An episode whose `fetchVideo` returns nil is skipped, not fatal — the rest
   /// of the import still completes.
   @Test internal func skipsEpisodesWithoutAVideoAndKeepsTheRest() throws {

--- a/Tests/BrightDigitArgsTests/PodcastMatchingTests.swift
+++ b/Tests/BrightDigitArgsTests/PodcastMatchingTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+
+@testable import BrightDigitPodcast
+
+private struct StubAudio: AudioPodcastItem {
+  let podcastID = "pod"
+  let episodeNo: Int
+  let slug: String
+  let title: String
+  let date = Date(timeIntervalSince1970: 0)
+  let summary = ""
+  let content: String
+  let duration: TimeInterval = 100
+  let imageURL = URL(fileURLWithPath: "/image.png")
+  let audioURL = URL(fileURLWithPath: "/audio.mp3")
+}
+
+private struct StubVideo: VideoYouTubeItem {
+  let youtubeID: String
+  let duration: TimeInterval = 200
+}
+
+internal struct PodcastMatchingTests {
+  /// An episode whose `fetchVideo` returns nil is skipped, not fatal — the rest
+  /// of the import still completes.
+  @Test internal func skipsEpisodesWithoutAVideoAndKeepsTheRest() throws {
+    let items: [AudioPodcastItem] = [
+      StubAudio(episodeNo: 1, slug: "one", title: "One", content: ""),
+      StubAudio(episodeNo: 2, slug: "two", title: "Two", content: ""),
+    ]
+
+    let sources = try BrightDigitPodcast.Source.episodesBasedOn(
+      rssItems: items
+    ) { item in
+      item.episodeNo == 1 ? StubVideo(youtubeID: "vid1") : nil
+    }
+
+    #expect(sources.count == 1)
+    #expect(sources.first?.episodeNo == 1)
+  }
+}

--- a/Tests/BrightDigitArgsTests/YouTubeIDExtractionTests.swift
+++ b/Tests/BrightDigitArgsTests/YouTubeIDExtractionTests.swift
@@ -1,0 +1,38 @@
+import Testing
+
+@testable import BrightDigitArgs
+
+internal struct YouTubeIDExtractionTests {
+  @Test internal func extractsWatchIDFromShowNotes() {
+    let html = """
+      <p>Watch this episode:
+      <a href="https://www.youtube.com/watch?v=1U3pXddDYo0" \
+      title="Click here to watch a video of this episode.">Watch</a></p>
+      """
+    #expect(Import.PodcastCommand.youtubeIDs(in: html) == ["1U3pXddDYo0"])
+  }
+
+  @Test internal func extractsShortAndEmbedForms() {
+    #expect(
+      Import.PodcastCommand.youtubeIDs(in: "see https://youtu.be/abcDEF12345 now")
+        == ["abcDEF12345"]
+    )
+    #expect(
+      Import.PodcastCommand.youtubeIDs(
+        in: #"<iframe src="https://www.youtube.com/embed/ABCdef-_123"></iframe>"#
+      ) == ["ABCdef-_123"]
+    )
+  }
+
+  @Test internal func dedupesAndIgnoresNonYouTubeLinks() {
+    let html = """
+      https://www.youtube.com/watch?v=1U3pXddDYo0 and again \
+      https://youtu.be/1U3pXddDYo0 plus https://example.com/watch?v=notanid000
+      """
+    #expect(Import.PodcastCommand.youtubeIDs(in: html) == ["1U3pXddDYo0"])
+  }
+
+  @Test internal func emptyWhenNoYouTubeLink() {
+    #expect(Import.PodcastCommand.youtubeIDs(in: "no links here").isEmpty)
+  }
+}


### PR DESCRIPTION
## Problem

`import podcast` aborted with `missingVideoForEpisode` on episode #206. The importer paired RSS episodes to YouTube videos by **exact title**, and the titles differ slightly:

- RSS: `Platforms State of the Union 2026 with Peter Witham`
- YouTube: `Platforms State of the Union 2026 with @PeterWitham` (YouTube renders the @handle)

One mismatch aborted the entire import.

## Fix

- **Match by YouTube video id** embedded in the RSS show-notes (`…/watch?v=<id>`), with exact title as a fallback. New `Import.PodcastCommand.youtubeIDs(in:)` extracts ids from `watch`/`youtu.be`/`embed` URLs; `execute()` builds a by-id index alongside the title index.
- **Non-fatal on a true miss**: `BrightDigitPodcast.Source.episodesBasedOn` now `compactMap`s — a genuine no-video episode is skipped with a stderr warning instead of aborting. Removes the now-dead `MediaError`.

## Tests (new `BrightDigitArgsTests` target)

- `youtubeIDs(in:)`: extracts the #206 watch URL, handles `youtu.be`/`embed`, dedupes, ignores non-YouTube links.
- `episodesBasedOn`: an episode without a video is skipped and the rest are kept (no throw).

## Verification

`swift build` / `swift test` green. Re-ran `import podcast` against the live feeds: **exit 0**, episode #206 now written with `youtubeID: 1U3pXddDYo0` / `videoDuration: 2409` — matched by id despite the title difference; no episodes skipped.

The separate `import mailchimp` failure is tracked in its own issue (Spinetail decode + no per-campaign skip), deprioritized behind the Buttondown migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)