### PR TITLE
Add test coverage for NPMPublishPlugin & ButtondownKit; ignore generated files

### DIFF
--- a/Packages/BrightDigit/ButtondownKit/Tests/ButtondownKitTests/ButtondownClientTests.swift
+++ b/Packages/BrightDigit/ButtondownKit/Tests/ButtondownKitTests/ButtondownClientTests.swift
@@ -160,4 +160,37 @@ import Testing
       _ = try ButtondownClient.fromEnvironment()
     }
   }
+
+  /// A documented error status on `sendDraft` surfaces as `unexpectedResponse`.
+  @Test internal func sendDraftUnexpectedStatusThrows() async throws {
+    let transport = MockTransport(responses: [
+      "POST /emails/\(Self.emailID)/send-draft": [
+        .init(status: 403, json: #"{"detail":"nope","code":"forbidden"}"#)
+      ]
+    ])
+    let client = try makeClient(transport)
+
+    await #expect(throws: ButtondownClient.ClientError.unexpectedResponse) {
+      try await client.sendDraft(id: Self.emailID)
+    }
+  }
+
+  /// A documented error status on `email(id:)` surfaces as `unexpectedResponse`.
+  @Test internal func retrieveEmailUnexpectedStatusThrows() async throws {
+    let transport = MockTransport(responses: [
+      "GET /emails/\(Self.emailID)": [
+        .init(status: 403, json: #"{"detail":"nope","code":"forbidden"}"#)
+      ]
+    ])
+    let client = try makeClient(transport)
+
+    await #expect(throws: ButtondownClient.ClientError.unexpectedResponse) {
+      _ = try await client.email(id: Self.emailID)
+    }
+  }
+
+  /// `init(apiKey:)` builds a live-transport client without throwing.
+  @Test internal func initWithAPIKeySucceeds() throws {
+    _ = try ButtondownClient(apiKey: Self.apiKey)
+  }
 }

--- a/Packages/BrightDigit/ButtondownKit/codecov.yml
+++ b/Packages/BrightDigit/ButtondownKit/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "Tests"
+  - "Sources/ButtondownKit/Generated"

--- a/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/ArgumentTests.swift
+++ b/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/ArgumentTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Publish
+import XCTest
+
+@testable import NPMPublishPlugin
+
+internal final class ArgumentTests: XCTestCase {
+  internal func testStringArgumentReturnsValueUnchanged() {
+    let argument: NPM.Argument = .string("--yes")
+
+    XCTAssertEqual(argument.relativePath(basedOn: [:]), "--yes")
+  }
+
+  internal func testStringLiteralInitProducesStringCase() {
+    let argument: NPM.Argument = "--flag"
+
+    guard case .string(let value) = argument else {
+      return XCTFail("expected .string case")
+    }
+    XCTAssertEqual(value, "--flag")
+  }
+
+  internal func testPathArgumentResolvesAndQuotesMappedValue() {
+    let path: OutputPath = .file(.init("output.css"))
+    let map: [OutputPath: String] = [path: "build/output.css"]
+    let argument: NPM.Argument = .path(path)
+
+    XCTAssertEqual(argument.relativePath(basedOn: map), "\"build/output.css\"")
+  }
+
+  internal func testPathArgumentFallsBackToQuotedDefaultWhenMissing() {
+    let path: OutputPath = .folder(.init("dist"))
+    let argument: NPM.Argument = .path(path)
+
+    XCTAssertEqual(argument.relativePath(basedOn: [:]), "\"\"")
+    XCTAssertEqual(
+      argument.relativePath(basedOn: [:], withDefaultValue: "fallback"),
+      "\"fallback\""
+    )
+  }
+}

--- a/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/ArgumentTests.swift
+++ b/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/ArgumentTests.swift
@@ -1,41 +1,45 @@
-import Foundation
 import Publish
-import XCTest
+import Testing
 
 @testable import NPMPublishPlugin
 
-internal final class ArgumentTests: XCTestCase {
-  internal func testStringArgumentReturnsValueUnchanged() {
+@Suite("NPM Argument")
+internal struct ArgumentTests {
+  @Test("String argument returns its value unchanged")
+  internal func stringArgumentReturnsValueUnchanged() {
     let argument: NPM.Argument = .string("--yes")
 
-    XCTAssertEqual(argument.relativePath(basedOn: [:]), "--yes")
+    #expect(argument.relativePath(basedOn: [:]) == "--yes")
   }
 
-  internal func testStringLiteralInitProducesStringCase() {
+  @Test("String literal initializer produces a .string case")
+  internal func stringLiteralInitProducesStringCase() {
     let argument: NPM.Argument = "--flag"
 
     guard case .string(let value) = argument else {
-      return XCTFail("expected .string case")
+      Issue.record("expected .string case")
+      return
     }
-    XCTAssertEqual(value, "--flag")
+    #expect(value == "--flag")
   }
 
-  internal func testPathArgumentResolvesAndQuotesMappedValue() {
+  @Test("Path argument resolves and quotes the mapped value")
+  internal func pathArgumentResolvesAndQuotesMappedValue() {
     let path: OutputPath = .file(.init("output.css"))
     let map: [OutputPath: String] = [path: "build/output.css"]
     let argument: NPM.Argument = .path(path)
 
-    XCTAssertEqual(argument.relativePath(basedOn: map), "\"build/output.css\"")
+    #expect(argument.relativePath(basedOn: map) == "\"build/output.css\"")
   }
 
-  internal func testPathArgumentFallsBackToQuotedDefaultWhenMissing() {
+  @Test("Path argument falls back to the quoted default when missing")
+  internal func pathArgumentFallsBackToQuotedDefaultWhenMissing() {
     let path: OutputPath = .folder(.init("dist"))
     let argument: NPM.Argument = .path(path)
 
-    XCTAssertEqual(argument.relativePath(basedOn: [:]), "\"\"")
-    XCTAssertEqual(
-      argument.relativePath(basedOn: [:], withDefaultValue: "fallback"),
-      "\"fallback\""
+    #expect(argument.relativePath(basedOn: [:]) == "\"\"")
+    #expect(
+      argument.relativePath(basedOn: [:], withDefaultValue: "fallback") == "\"fallback\""
     )
   }
 }

--- a/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/BuilderTests.swift
+++ b/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/BuilderTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Publish
+import XCTest
+
+@testable import NPMPublishPlugin
+
+internal final class BuilderTests: XCTestCase {
+  internal func testArgumentBuilderWrapsSingleArgument() {
+    let result = NPM.ArgumentBuilder.buildExpression(.string("--yes"))
+
+    XCTAssertEqual(result.count, 1)
+    guard case .string(let value) = result[0] else {
+      return XCTFail("expected .string case")
+    }
+    XCTAssertEqual(value, "--yes")
+  }
+
+  internal func testArgumentBuilderWrapsOutputPathAsPathArgument() {
+    let path: OutputPath = .file(.init("a.css"))
+
+    let result = NPM.ArgumentBuilder.buildExpression(path)
+
+    XCTAssertEqual(result.count, 1)
+    guard case .path(let wrapped) = result[0] else {
+      return XCTFail("expected .path case")
+    }
+    XCTAssertEqual(wrapped, path)
+  }
+
+  internal func testArgumentBuilderBlockFlattensComponents() {
+    let result = NPM.ArgumentBuilder.buildBlock(
+      [.string("a")],
+      [.string("b"), .string("c")]
+    )
+
+    XCTAssertEqual(result.count, 3)
+  }
+
+  internal func testJobBuilderCollectsJobs() {
+    let jobs = NPM.JobBuilder.buildBlock(
+      .init(subcommand: .ci),
+      .init(subcommand: .run)
+    )
+
+    XCTAssertEqual(jobs.count, 2)
+    XCTAssertEqual(jobs[0].subcommand.string, "ci")
+    XCTAssertEqual(jobs[1].subcommand.string, "run")
+  }
+
+  internal func testJobBuilderInitAppliesArgumentBuilder() {
+    let job = NPM.Job(subcommand: .run) {
+      "--silent"
+      OutputPath.file(.init("out.css"))
+    }
+
+    XCTAssertEqual(job.arguments.count, 2)
+  }
+}

--- a/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/BuilderTests.swift
+++ b/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/BuilderTests.swift
@@ -1,58 +1,65 @@
-import Foundation
 import Publish
-import XCTest
+import Testing
 
 @testable import NPMPublishPlugin
 
-internal final class BuilderTests: XCTestCase {
-  internal func testArgumentBuilderWrapsSingleArgument() {
+@Suite("NPM Builders")
+internal struct BuilderTests {
+  @Test("ArgumentBuilder wraps a single argument")
+  internal func argumentBuilderWrapsSingleArgument() {
     let result = NPM.ArgumentBuilder.buildExpression(.string("--yes"))
 
-    XCTAssertEqual(result.count, 1)
+    #expect(result.count == 1)
     guard case .string(let value) = result[0] else {
-      return XCTFail("expected .string case")
+      Issue.record("expected .string case")
+      return
     }
-    XCTAssertEqual(value, "--yes")
+    #expect(value == "--yes")
   }
 
-  internal func testArgumentBuilderWrapsOutputPathAsPathArgument() {
+  @Test("ArgumentBuilder wraps an output path as a path argument")
+  internal func argumentBuilderWrapsOutputPathAsPathArgument() {
     let path: OutputPath = .file(.init("a.css"))
 
     let result = NPM.ArgumentBuilder.buildExpression(path)
 
-    XCTAssertEqual(result.count, 1)
+    #expect(result.count == 1)
     guard case .path(let wrapped) = result[0] else {
-      return XCTFail("expected .path case")
+      Issue.record("expected .path case")
+      return
     }
-    XCTAssertEqual(wrapped, path)
+    #expect(wrapped == path)
   }
 
-  internal func testArgumentBuilderBlockFlattensComponents() {
+  @Test("ArgumentBuilder block flattens its components")
+  internal func argumentBuilderBlockFlattensComponents() {
     let result = NPM.ArgumentBuilder.buildBlock(
       [.string("a")],
       [.string("b"), .string("c")]
     )
 
-    XCTAssertEqual(result.count, 3)
+    #expect(result.count == 3)
   }
 
-  internal func testJobBuilderCollectsJobs() {
+  @Test("JobBuilder collects jobs in order")
+  internal func jobBuilderCollectsJobs() {
     let jobs = NPM.JobBuilder.buildBlock(
       .init(subcommand: .ci),
       .init(subcommand: .run)
     )
 
-    XCTAssertEqual(jobs.count, 2)
-    XCTAssertEqual(jobs[0].subcommand.string, "ci")
-    XCTAssertEqual(jobs[1].subcommand.string, "run")
+    #expect(jobs.count == 2)
+    #expect(jobs[0].subcommand.string == "ci")
+    #expect(jobs[1].subcommand.string == "run")
   }
 
-  internal func testJobBuilderInitAppliesArgumentBuilder() {
+  @Test("Job builder initializer applies the ArgumentBuilder")
+  internal func jobBuilderInitAppliesArgumentBuilder() {
     let job = NPM.Job(subcommand: .run) {
       "--silent"
       OutputPath.file(.init("out.css"))
     }
 
-    XCTAssertEqual(job.arguments.count, 2)
+    #expect(job.arguments.count == 2)
   }
 }

--- a/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/CommandTests.swift
+++ b/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/CommandTests.swift
@@ -1,21 +1,24 @@
-import Foundation
-import XCTest
+import Testing
 
 @testable import NPMPublishPlugin
 
-internal final class CommandTests: XCTestCase {
-  internal func testPredefinedCommands() {
-    XCTAssertEqual(NPM.Command.ci.string, "ci")
-    XCTAssertEqual(NPM.Command.run.string, "run")
+@Suite("NPM Command")
+internal struct CommandTests {
+  @Test("Predefined commands expose their strings")
+  internal func predefinedCommands() {
+    #expect(NPM.Command.ci.string == "ci")
+    #expect(NPM.Command.run.string == "run")
   }
 
-  internal func testInitWithString() {
-    XCTAssertEqual(NPM.Command("install").string, "install")
+  @Test("Initializer stores the command string")
+  internal func initWithString() {
+    #expect(NPM.Command("install").string == "install")
   }
 
-  internal func testStringLiteralInit() {
+  @Test("String literal initializer stores the command string")
+  internal func stringLiteralInit() {
     let command: NPM.Command = "test"
 
-    XCTAssertEqual(command.string, "test")
+    #expect(command.string == "test")
   }
 }

--- a/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/CommandTests.swift
+++ b/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/CommandTests.swift
@@ -1,0 +1,21 @@
+import Foundation
+import XCTest
+
+@testable import NPMPublishPlugin
+
+internal final class CommandTests: XCTestCase {
+  internal func testPredefinedCommands() {
+    XCTAssertEqual(NPM.Command.ci.string, "ci")
+    XCTAssertEqual(NPM.Command.run.string, "run")
+  }
+
+  internal func testInitWithString() {
+    XCTAssertEqual(NPM.Command("install").string, "install")
+  }
+
+  internal func testStringLiteralInit() {
+    let command: NPM.Command = "test"
+
+    XCTAssertEqual(command.string, "test")
+  }
+}

--- a/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/FolderResolvingContext.swift
+++ b/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/FolderResolvingContext.swift
@@ -1,0 +1,28 @@
+import Files
+import Foundation
+import Publish
+
+@testable import NPMPublishPlugin
+
+/// A minimal ``NPMContext`` that resolves any path to a fixed folder and records
+/// the requested path, used to exercise the `.path` branch of
+/// ``NPM/Settings/folder(usingContext:)``.
+internal final class FolderResolvingContext: NPMContext {
+  internal private(set) var requestedPath: Publish.Path?
+
+  private let resolved: Files.Folder
+
+  internal init(resolved: Files.Folder) {
+    self.resolved = resolved
+  }
+
+  // swiftlint:disable:next unavailable_function
+  internal func createOutput(for _: OutputPath) throws -> Output {
+    fatalError("unavailable")
+  }
+
+  internal func folder(at path: Publish.Path) throws -> Files.Folder {
+    requestedPath = path
+    return resolved
+  }
+}

--- a/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/JobTests.swift
+++ b/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/JobTests.swift
@@ -1,13 +1,15 @@
 import Foundation
 import Publish
-import XCTest
+import Testing
 
 import struct Files.Folder
 
 @testable import NPMPublishPlugin
 
-internal final class JobTests: XCTestCase {
-  internal func testDesignatedInitStoresValues() {
+@Suite("NPM Job")
+internal struct JobTests {
+  @Test("Designated initializer stores its values")
+  internal func designatedInitStoresValues() {
     let path: OutputPath = .file(.init("a.css"))
     let job = NPM.Job(
       subcommand: .run,
@@ -15,31 +17,34 @@ internal final class JobTests: XCTestCase {
       arguments: [.string("--silent")]
     )
 
-    XCTAssertEqual(job.subcommand.string, "run")
-    XCTAssertEqual(job.outputRelativePaths, [path])
-    XCTAssertEqual(job.arguments.count, 1)
+    #expect(job.subcommand.string == "run")
+    #expect(job.outputRelativePaths == [path])
+    #expect(job.arguments.count == 1)
   }
 
-  internal func testCIHelperBuildsCISubcommand() {
+  @Test("ci() helper builds the ci subcommand")
+  internal func ciHelperBuildsCISubcommand() {
     let job = ci()
 
-    XCTAssertEqual(job.subcommand.string, "ci")
-    XCTAssertTrue(job.outputRelativePaths.isEmpty)
-    XCTAssertTrue(job.arguments.isEmpty)
+    #expect(job.subcommand.string == "ci")
+    #expect(job.outputRelativePaths.isEmpty)
+    #expect(job.arguments.isEmpty)
   }
 
-  internal func testRunHelperBuildsRunSubcommandWithPathsAndArguments() {
+  @Test("run() helper builds the run subcommand with paths and arguments")
+  internal func runHelperBuildsRunSubcommandWithPathsAndArguments() {
     let path: OutputPath = .folder(.init("dist"))
     let job = NPMPublishPlugin.run(paths: [path]) {
       "--prod"
     }
 
-    XCTAssertEqual(job.subcommand.string, "run")
-    XCTAssertEqual(job.outputRelativePaths, [path])
-    XCTAssertEqual(job.arguments.count, 1)
+    #expect(job.subcommand.string == "run")
+    #expect(job.outputRelativePaths == [path])
+    #expect(job.arguments.count == 1)
   }
 
-  internal func testCreateOutputMapsPathsToRelativePaths() throws {
+  @Test("createOutput maps paths to their relative paths")
+  internal func createOutputMapsPathsToRelativePaths() throws {
     let fileName = UUID().uuidString
     let path: OutputPath = .file(.init(fileName))
     let job = NPM.Job(subcommand: .run, outputRelativePaths: [path])
@@ -49,6 +54,6 @@ internal final class JobTests: XCTestCase {
       relativeTo: .temporary
     )
 
-    XCTAssertEqual(map[path], fileName)
+    #expect(map[path] == fileName)
   }
 }

--- a/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/JobTests.swift
+++ b/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/JobTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Publish
+import XCTest
+
+import struct Files.Folder
+
+@testable import NPMPublishPlugin
+
+internal final class JobTests: XCTestCase {
+  internal func testDesignatedInitStoresValues() {
+    let path: OutputPath = .file(.init("a.css"))
+    let job = NPM.Job(
+      subcommand: .run,
+      outputRelativePaths: [path],
+      arguments: [.string("--silent")]
+    )
+
+    XCTAssertEqual(job.subcommand.string, "run")
+    XCTAssertEqual(job.outputRelativePaths, [path])
+    XCTAssertEqual(job.arguments.count, 1)
+  }
+
+  internal func testCIHelperBuildsCISubcommand() {
+    let job = ci()
+
+    XCTAssertEqual(job.subcommand.string, "ci")
+    XCTAssertTrue(job.outputRelativePaths.isEmpty)
+    XCTAssertTrue(job.arguments.isEmpty)
+  }
+
+  internal func testRunHelperBuildsRunSubcommandWithPathsAndArguments() {
+    let path: OutputPath = .folder(.init("dist"))
+    let job = NPMPublishPlugin.run(paths: [path]) {
+      "--prod"
+    }
+
+    XCTAssertEqual(job.subcommand.string, "run")
+    XCTAssertEqual(job.outputRelativePaths, [path])
+    XCTAssertEqual(job.arguments.count, 1)
+  }
+
+  internal func testCreateOutputMapsPathsToRelativePaths() throws {
+    let fileName = UUID().uuidString
+    let path: OutputPath = .file(.init(fileName))
+    let job = NPM.Job(subcommand: .run, outputRelativePaths: [path])
+
+    let map = try job.createOutput(
+      using: MockPublishingContextable(),
+      relativeTo: .temporary
+    )
+
+    XCTAssertEqual(map[path], fileName)
+  }
+}

--- a/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/NPMInvocationErrorTests.swift
+++ b/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/NPMInvocationErrorTests.swift
@@ -1,0 +1,19 @@
+import Foundation
+import XCTest
+
+@testable import NPMPublishPlugin
+
+internal final class NPMInvocationErrorTests: XCTestCase {
+  internal func testDescriptionFormatsCommandStatusAndStandardError() {
+    let error = NPMInvocationError(
+      command: "cd /tmp && npm ci",
+      terminationStatus: .exited(1),
+      standardError: "boom"
+    )
+
+    XCTAssertEqual(
+      error.description,
+      "npm command failed (\(error.terminationStatus)): cd /tmp && npm ci\nboom"
+    )
+  }
+}

--- a/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/NPMInvocationErrorTests.swift
+++ b/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/NPMInvocationErrorTests.swift
@@ -1,19 +1,20 @@
-import Foundation
-import XCTest
+import Testing
 
 @testable import NPMPublishPlugin
 
-internal final class NPMInvocationErrorTests: XCTestCase {
-  internal func testDescriptionFormatsCommandStatusAndStandardError() {
+@Suite("NPM Invocation Error")
+internal struct NPMInvocationErrorTests {
+  @Test("Description formats command, status, and standard error")
+  internal func descriptionFormatsCommandStatusAndStandardError() {
     let error = NPMInvocationError(
       command: "cd /tmp && npm ci",
       terminationStatus: .exited(1),
       standardError: "boom"
     )
 
-    XCTAssertEqual(
-      error.description,
-      "npm command failed (\(error.terminationStatus)): cd /tmp && npm ci\nboom"
+    #expect(
+      error.description
+        == "npm command failed (\(error.terminationStatus)): cd /tmp && npm ci\nboom"
     )
   }
 }

--- a/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/NPMInvocationTests.swift
+++ b/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/NPMInvocationTests.swift
@@ -19,4 +19,23 @@ internal final class NPMInvocationTests: XCTestCase {
 
     XCTAssertEqual(npmCommand.string, commandString)
   }
+
+  internal func testNPMResolvesArgumentsAndOutputPaths() throws {
+    let cssName = UUID().uuidString
+    let outputPath: OutputPath = .file(.init(cssName))
+
+    let invocation: NPMInvocation = try .npm(
+      .init(
+        subcommand: .run,
+        outputRelativePaths: [outputPath],
+        arguments: [.string("build"), .path(outputPath)]
+      ),
+      withSettings: NPM.Settings(location: .folder(Folder.temporary)),
+      andContext: MockPublishingContextable()
+    )
+
+    XCTAssertEqual(invocation.npmPath, "npm")
+    XCTAssertEqual(invocation.arguments, ["run", "build", "\"\(cssName)\""])
+    XCTAssertEqual(invocation.string, "npm run build \"\(cssName)\"")
+  }
 }

--- a/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/NPMInvocationTests.swift
+++ b/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/NPMInvocationTests.swift
@@ -1,12 +1,15 @@
+import Foundation
 import Publish
-import XCTest
+import Testing
 
 import struct Files.Folder
 
 @testable import NPMPublishPlugin
 
-internal final class NPMInvocationTests: XCTestCase {
-  internal func testNPM() throws {
+@Suite("NPM Invocation")
+internal struct NPMInvocationTests {
+  @Test("Builds the expected command string")
+  internal func buildsExpectedCommandString() throws {
     let commandString = "npm init --yes"
 
     let npmCommand: NPMInvocation = try .npm(
@@ -17,10 +20,11 @@ internal final class NPMInvocationTests: XCTestCase {
       andContext: MockPublishingContextable()
     )
 
-    XCTAssertEqual(npmCommand.string, commandString)
+    #expect(npmCommand.string == commandString)
   }
 
-  internal func testNPMResolvesArgumentsAndOutputPaths() throws {
+  @Test("Resolves arguments and output paths")
+  internal func resolvesArgumentsAndOutputPaths() throws {
     let cssName = UUID().uuidString
     let outputPath: OutputPath = .file(.init(cssName))
 
@@ -34,8 +38,8 @@ internal final class NPMInvocationTests: XCTestCase {
       andContext: MockPublishingContextable()
     )
 
-    XCTAssertEqual(invocation.npmPath, "npm")
-    XCTAssertEqual(invocation.arguments, ["run", "build", "\"\(cssName)\""])
-    XCTAssertEqual(invocation.string, "npm run build \"\(cssName)\"")
+    #expect(invocation.npmPath == "npm")
+    #expect(invocation.arguments == ["run", "build", "\"\(cssName)\""])
+    #expect(invocation.string == "npm run build \"\(cssName)\"")
   }
 }

--- a/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/SettingsTests.swift
+++ b/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/SettingsTests.swift
@@ -1,0 +1,39 @@
+import Files
+import Foundation
+import Publish
+import XCTest
+
+@testable import NPMPublishPlugin
+
+internal final class SettingsTests: XCTestCase {
+  internal func testNpmPathDefaultsToNpm() {
+    XCTAssertEqual(NPM.Settings(location: .folder(.temporary)).npmPath, "npm")
+    XCTAssertEqual(NPM.Settings(folder: .temporary).npmPath, "npm")
+    XCTAssertEqual(NPM.Settings(path: Path(".")).npmPath, "npm")
+  }
+
+  internal func testCustomNpmPathIsPreserved() {
+    XCTAssertEqual(
+      NPM.Settings(npmPath: "/usr/local/bin/npm", folder: .temporary).npmPath,
+      "/usr/local/bin/npm"
+    )
+  }
+
+  internal func testFolderLocationReturnsFolderDirectly() throws {
+    let settings = NPM.Settings(location: .folder(.temporary))
+
+    let resolved = try settings.folder(usingContext: MockPublishingContextable())
+
+    XCTAssertEqual(resolved.path, Folder.temporary.path)
+  }
+
+  internal func testPathLocationDelegatesToContext() throws {
+    let context = FolderResolvingContext(resolved: .temporary)
+    let settings = NPM.Settings(path: Path("some/where"))
+
+    let resolved = try settings.folder(usingContext: context)
+
+    XCTAssertEqual(resolved.path, Folder.temporary.path)
+    XCTAssertEqual(context.requestedPath?.string, "some/where")
+  }
+}

--- a/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/SettingsTests.swift
+++ b/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/SettingsTests.swift
@@ -1,39 +1,43 @@
 import Files
-import Foundation
 import Publish
-import XCTest
+import Testing
 
 @testable import NPMPublishPlugin
 
-internal final class SettingsTests: XCTestCase {
-  internal func testNpmPathDefaultsToNpm() {
-    XCTAssertEqual(NPM.Settings(location: .folder(.temporary)).npmPath, "npm")
-    XCTAssertEqual(NPM.Settings(folder: .temporary).npmPath, "npm")
-    XCTAssertEqual(NPM.Settings(path: Path(".")).npmPath, "npm")
+@Suite("NPM Settings")
+internal struct SettingsTests {
+  @Test("npmPath defaults to \"npm\"")
+  internal func npmPathDefaultsToNpm() {
+    #expect(NPM.Settings(location: .folder(.temporary)).npmPath == "npm")
+    #expect(NPM.Settings(folder: .temporary).npmPath == "npm")
+    #expect(NPM.Settings(path: Path(".")).npmPath == "npm")
   }
 
-  internal func testCustomNpmPathIsPreserved() {
-    XCTAssertEqual(
-      NPM.Settings(npmPath: "/usr/local/bin/npm", folder: .temporary).npmPath,
-      "/usr/local/bin/npm"
+  @Test("Custom npmPath is preserved")
+  internal func customNpmPathIsPreserved() {
+    #expect(
+      NPM.Settings(npmPath: "/usr/local/bin/npm", folder: .temporary).npmPath
+        == "/usr/local/bin/npm"
     )
   }
 
-  internal func testFolderLocationReturnsFolderDirectly() throws {
+  @Test("Folder location returns the folder directly")
+  internal func folderLocationReturnsFolderDirectly() throws {
     let settings = NPM.Settings(location: .folder(.temporary))
 
     let resolved = try settings.folder(usingContext: MockPublishingContextable())
 
-    XCTAssertEqual(resolved.path, Folder.temporary.path)
+    #expect(resolved.path == Folder.temporary.path)
   }
 
-  internal func testPathLocationDelegatesToContext() throws {
+  @Test("Path location delegates resolution to the context")
+  internal func pathLocationDelegatesToContext() throws {
     let context = FolderResolvingContext(resolved: .temporary)
     let settings = NPM.Settings(path: Path("some/where"))
 
     let resolved = try settings.folder(usingContext: context)
 
-    XCTAssertEqual(resolved.path, Folder.temporary.path)
-    XCTAssertEqual(context.requestedPath?.string, "some/where")
+    #expect(resolved.path == Folder.temporary.path)
+    #expect(context.requestedPath?.string == "some/where")
   }
 }

--- a/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/URLRelativePathTests.swift
+++ b/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/URLRelativePathTests.swift
@@ -1,34 +1,39 @@
 import Foundation
-import XCTest
+import Testing
 
 @testable import NPMPublishPlugin
 
-internal final class URLRelativePathTests: XCTestCase {
-  internal func testNestedChildRelativeToAncestor() {
+@Suite("URL Relative Path")
+internal struct URLRelativePathTests {
+  @Test("Nested child resolves relative to its ancestor")
+  internal func nestedChildRelativeToAncestor() {
     let base = URL(fileURLWithPath: "/a/b", isDirectory: true)
     let dest = URL(fileURLWithPath: "/a/b/c/d", isDirectory: true)
 
-    XCTAssertEqual(dest.relativePath(from: base), "c/d")
+    #expect(dest.relativePath(from: base) == "c/d")
   }
 
-  internal func testSiblingPathsClimbWithDotDot() {
+  @Test("Sibling paths climb with ..")
+  internal func siblingPathsClimbWithDotDot() {
     let base = URL(fileURLWithPath: "/a/b/c", isDirectory: true)
     let dest = URL(fileURLWithPath: "/a/b/d", isDirectory: true)
 
-    XCTAssertEqual(dest.relativePath(from: base), "../d")
+    #expect(dest.relativePath(from: base) == "../d")
   }
 
-  internal func testIdenticalURLsReturnEmptyString() {
+  @Test("Identical URLs return an empty string")
+  internal func identicalURLsReturnEmptyString() {
     let url = URL(fileURLWithPath: "/a/b/c", isDirectory: true)
 
-    XCTAssertEqual(url.relativePath(from: url), "")
+    #expect(url.relativePath(from: url)?.isEmpty == true)
   }
 
-  internal func testNonFileURLReturnsNil() throws {
+  @Test("Non-file URLs return nil")
+  internal func nonFileURLReturnsNil() throws {
     let base = URL(fileURLWithPath: "/a/b", isDirectory: true)
-    let remote = try XCTUnwrap(URL(string: "https://example.com/a/b"))
+    let remote = try #require(URL(string: "https://example.com/a/b"))
 
-    XCTAssertNil(remote.relativePath(from: base))
-    XCTAssertNil(base.relativePath(from: remote))
+    #expect(remote.relativePath(from: base) == nil)
+    #expect(base.relativePath(from: remote) == nil)
   }
 }

--- a/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/URLRelativePathTests.swift
+++ b/Packages/BrightDigit/NPMPublishPlugin/Tests/NPMPublishPluginTests/URLRelativePathTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import XCTest
+
+@testable import NPMPublishPlugin
+
+internal final class URLRelativePathTests: XCTestCase {
+  internal func testNestedChildRelativeToAncestor() {
+    let base = URL(fileURLWithPath: "/a/b", isDirectory: true)
+    let dest = URL(fileURLWithPath: "/a/b/c/d", isDirectory: true)
+
+    XCTAssertEqual(dest.relativePath(from: base), "c/d")
+  }
+
+  internal func testSiblingPathsClimbWithDotDot() {
+    let base = URL(fileURLWithPath: "/a/b/c", isDirectory: true)
+    let dest = URL(fileURLWithPath: "/a/b/d", isDirectory: true)
+
+    XCTAssertEqual(dest.relativePath(from: base), "../d")
+  }
+
+  internal func testIdenticalURLsReturnEmptyString() {
+    let url = URL(fileURLWithPath: "/a/b/c", isDirectory: true)
+
+    XCTAssertEqual(url.relativePath(from: url), "")
+  }
+
+  internal func testNonFileURLReturnsNil() throws {
+    let base = URL(fileURLWithPath: "/a/b", isDirectory: true)
+    let remote = try XCTUnwrap(URL(string: "https://example.com/a/b"))
+
+    XCTAssertNil(remote.relativePath(from: base))
+    XCTAssertNil(base.relativePath(from: remote))
+  }
+}

--- a/Packages/BrightDigit/SwiftTube/codecov.yml
+++ b/Packages/BrightDigit/SwiftTube/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "Tests"
+  - "Sources/SwiftTube/Generated"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,3 @@
 ignore:
   - "Tests"
+  - "**/Generated/**"


### PR DESCRIPTION
## Context

Follow-up to the Phase 4 OpenAPI & dependency migration (#109), which left low patch coverage on first-party code. The migration restructured npm shell invocation into an `NPM/` folder and deleted `ShellOutCommand.swift` + its test without porting the tests, and added OpenAPI-generated client code that drags the percentage down.

This PR adds **pure-logic unit tests** for the changed first-party code and excludes generated code from coverage so the percentage reflects hand-written code.

## Part A — Exclude generated OpenAPI files from coverage
- Root `codecov.yml`: ignore `**/Generated/**`.
- New per-package `codecov.yml` for **ButtondownKit** and **SwiftTube**, each ignoring their `Sources/.../Generated` dir + `Tests`.

## Part B — Pure-logic unit tests (no subprocess / Publish integration)

**NPMPublishPlugin** (26 new tests across 8 files), covering the restructured `NPM/` types:
- `URL.relativePath(from:)` (was 0%)
- `NPM.Argument.relativePath(basedOn:)` — string / path / default cases
- `ArgumentBuilder` + `JobBuilder` result builders (JobBuilder was 0%)
- `Command` predefined/literal inits
- `Settings` — three inits, default `npmPath`, `folder(usingContext:)` both branches (via a small `FolderResolvingContext` mock)
- `Job` — inits, `ci()`/`run()` helpers, `createOutput(...)`
- `NPMInvocationError.description` (was 0%)
- expanded `NPMInvocation.npm(...)` factory with argument + output-path resolution

Left uncovered by design: `NPMInvocation.run(at:)` and `PublishingStep.npm(...)` (subprocess / Publish-pipeline integration).

**ButtondownKit** (3 new tests): `ButtondownClient` `sendDraft`/`email(id:)` error paths (`unexpectedResponse`) and `init(apiKey:)`, all via the existing `MockTransport`.

## Verification
- NPMPublishPlugin: **31 tests pass**; ButtondownKit: **9 tests pass**.
- Per-package `swift-format --strict` and `swiftlint --strict` both clean.
- Tests live in each package's own `Tests/` dir, so the `packages.yaml` matrix runs them and re-uploads coverage under the respective Codecov flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)