### PR TITLE
Restore Linux code coverage under Swift 6.4 (#92)

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -136,15 +136,20 @@ jobs:
             apt-get update -q
             apt-get install -y --no-install-recommends curl ca-certificates
           fi
-      - uses: sersoft-gmbh/swift-coverage-action@v5
+      # brightdigit fork of swift-coverage-action: upstream @v5 can't pair the
+      # profdata with the test binary under Swift 6.4's new swiftbuild layout
+      # (.build/out/Products/<config>-linux-<arch>/<Name>.so + <Name>-test-runner,
+      # no .xctest), so Linux coverage silently dropped (issue #92). The fork
+      # detects the .so test bundle; pinned by SHA. Re-upstream and switch back
+      # to a tagged sersoft-gmbh release once merged.
+      - uses: brightdigit/swift-coverage-action@2f8538f723b99ab2406ac3a0e5b3355a9de4cf6c
         if: steps.build.outputs.contains-code-coverage == 'true'
         id: coverage-files
         with:
           search-paths: ${{ matrix.package.path }}/.build
-          # Swift 6.4 on Linux emits profdata that swift-coverage-action@v5 cannot
-          # convert (new .build/out/Products layout); macOS converts fine. Keep
-          # Linux coverage best-effort so a conversion miss doesn't fail the build.
-          fail-on-empty-output: false
+          # Guard restored: a conversion miss is fatal again so a Linux-coverage
+          # regression can't slip through silently (issue #92).
+          fail-on-empty-output: true
       - name: Upload coverage to Codecov
         if: steps.build.outputs.contains-code-coverage == 'true'
         uses: codecov/codecov-action@v7


### PR DESCRIPTION
Closes #92.

## Problem

Under the Swift **6.4** Linux toolchain, `brightdigit/swift-build@v1` runs `swift test --enable-code-coverage` and the new **swiftbuild** engine emits an Xcode-like layout: `.build/out/Products/<config>-linux-<arch>/`. The test bundle is `<Name>Tests.so` (the instrumented binary) paired with a `<Name>Tests-test-runner` launcher stub — **there is no `.xctest`**. `sersoft-gmbh/swift-coverage-action@v5` only matches `app|framework|xctest`, so it found the profdata but couldn't pair a binary → `No coverage files found` → Linux coverage was silently dropped. The earlier mitigation set `fail-on-empty-output: false`, which hid the miss rather than fixing it.

## Fix

- Point the Ubuntu coverage step at a patched fork, **`brightdigit/swift-coverage-action`** (pinned by SHA `2f8538f`). The patch teaches the SPM binary discovery to treat a `.so` as a test bundle when its `<base>-test-runner` sibling exists — gated to Linux, so the macOS/Xcode path is untouched. macOS legs stay on upstream `@v5` (its `.xctest` layout already works).
- **Re-enable `fail-on-empty-output: true`** on the Ubuntu step so a future conversion miss is fatal again — a Linux-coverage regression can't slip through silently.

## Verification

- **Local (Docker):** reproduced the new layout in `swiftlang/swift:nightly-6.4.x-noble`; `llvm-cov export` against `ButtondownKitTests.so` yields 147 source records. Ran the patched action end-to-end in `brightdigit/publish-xml:6.4` (node + llvm-cov) → exit 0, non-empty lcov.
- **CI (`workflow_dispatch`, trimmed matrix):** Packages CI run [27827770082](https://github.com/brightdigit/brightdigit.com/actions/runs/27827770082) — Ubuntu job converted `ButtondownKitTests.so.coverage.lcov` and uploaded to Codecov (flags `ButtondownKit,noble,swift-6.4`), green with `fail-on-empty-output: true`.

## Follow-ups (not in this PR)

- Upstream the patch to `sersoft-gmbh/swift-coverage-action`; switch the SHA pin back to a tagged release once merged.
- Optional combined guard that fails CI if *neither* Linux nor macOS uploaded any coverage (the per-leg `fail-on-empty-output: true` already covers each leg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)