### PR TITLE
Migrate SwiftSoupMarkdownGenerator tests to Swift Testing

### DIFF
--- a/Packages/BrightDigit/Contribute/Tests/ContributeTests/SwiftSoupMarkdownGeneratorTests.swift
+++ b/Packages/BrightDigit/Contribute/Tests/ContributeTests/SwiftSoupMarkdownGeneratorTests.swift
@@ -1,26 +1,29 @@
-import XCTest
+import Testing
 
 @testable import Contribute
 
-internal final class SwiftSoupMarkdownGeneratorTests: XCTestCase {
+@Suite("SwiftSoupMarkdownGenerator")
+internal struct SwiftSoupMarkdownGeneratorTests {
   private let sut = SwiftSoupMarkdownGenerator()
 
-  // MARK: Headings
+  // MARK: - Headings
 
-  internal func testHeadingLevels() throws {
-    XCTAssertEqual(try sut.markdown(fromHTML: "<h1>One</h1>"), "# One")
-    XCTAssertEqual(try sut.markdown(fromHTML: "<h2>Two</h2>"), "## Two")
-    XCTAssertEqual(try sut.markdown(fromHTML: "<h3>Three</h3>"), "### Three")
+  @Test("Heading levels h1 through h6")
+  internal func headingLevels() throws {
+    #expect(try sut.markdown(fromHTML: "<h1>One</h1>") == "# One")
+    #expect(try sut.markdown(fromHTML: "<h2>Two</h2>") == "## Two")
+    #expect(try sut.markdown(fromHTML: "<h3>Three</h3>") == "### Three")
     // Regression: h4 previously emitted level 3.
-    XCTAssertEqual(try sut.markdown(fromHTML: "<h4>Four</h4>"), "#### Four")
-    XCTAssertEqual(try sut.markdown(fromHTML: "<h5>Five</h5>"), "##### Five")
+    #expect(try sut.markdown(fromHTML: "<h4>Four</h4>") == "#### Four")
+    #expect(try sut.markdown(fromHTML: "<h5>Five</h5>") == "##### Five")
     // Regression: h6 was previously unhandled.
-    XCTAssertEqual(try sut.markdown(fromHTML: "<h6>Six</h6>"), "###### Six")
+    #expect(try sut.markdown(fromHTML: "<h6>Six</h6>") == "###### Six")
   }
 
-  // MARK: Inline formatting
+  // MARK: - Inline formatting
 
-  internal func testParagraphPreservesInlineFormatting() throws {
+  @Test("Paragraph preserves inline formatting")
+  internal func paragraphPreservesInlineFormatting() throws {
     let html = """
       <p>foo <a href="https://example.com">bar</a> \
       <strong>baz</strong> <em>qux</em> <code>zap</code></p>
@@ -28,70 +31,78 @@ internal final class SwiftSoupMarkdownGeneratorTests: XCTestCase {
     let markdown = try sut.markdown(fromHTML: html)
 
     // Regression: nested inline elements used to be flattened to plain text.
-    XCTAssertTrue(markdown.contains("[bar](https://example.com)"), markdown)
-    XCTAssertTrue(markdown.contains("**baz**"), markdown)
-    XCTAssertTrue(markdown.contains("*qux*"), markdown)
-    XCTAssertTrue(markdown.contains("`zap`"), markdown)
-    XCTAssertTrue(markdown.contains("foo"), markdown)
+    #expect(markdown.contains("[bar](https://example.com)"))
+    #expect(markdown.contains("**baz**"))
+    #expect(markdown.contains("*qux*"))
+    #expect(markdown.contains("`zap`"))
+    #expect(markdown.contains("foo"))
   }
 
-  // MARK: Lists
+  // MARK: - Lists
 
-  internal func testUnorderedList() throws {
+  @Test("Unordered list")
+  internal func unorderedList() throws {
     let markdown = try sut.markdown(fromHTML: "<ul><li>one</li><li>two</li></ul>")
-    XCTAssertTrue(markdown.contains("- one"), markdown)
-    XCTAssertTrue(markdown.contains("- two"), markdown)
+    #expect(markdown.contains("- one"))
+    #expect(markdown.contains("- two"))
   }
 
-  internal func testOrderedList() throws {
+  @Test("Ordered list")
+  internal func orderedList() throws {
     let markdown = try sut.markdown(fromHTML: "<ol><li>one</li><li>two</li></ol>")
     // swift-markdown's formatter emits "1." for each item (CommonMark
     // auto-increments ordered markers on render).
-    XCTAssertTrue(markdown.contains("1. one"), markdown)
-    XCTAssertTrue(markdown.contains("two"), markdown)
-    XCTAssertFalse(markdown.contains("- one"), markdown)
+    #expect(markdown.contains("1. one"))
+    #expect(markdown.contains("two"))
+    #expect(!markdown.contains("- one"))
   }
 
-  // MARK: Block quotes, rules, images
+  // MARK: - Block quotes, rules, images
 
-  internal func testBlockQuote() throws {
+  @Test("Block quote")
+  internal func blockQuote() throws {
     let markdown = try sut.markdown(fromHTML: "<blockquote><p>quoted</p></blockquote>")
-    XCTAssertTrue(markdown.contains("> quoted"), markdown)
+    #expect(markdown.contains("> quoted"))
   }
 
-  internal func testThematicBreak() throws {
+  @Test("Thematic break")
+  internal func thematicBreak() throws {
     let markdown = try sut.markdown(fromHTML: "<p>a</p><hr><p>b</p>")
-    XCTAssertTrue(markdown.contains("---"), markdown)
+    #expect(markdown.contains("---"))
   }
 
-  internal func testBlockImage() throws {
+  @Test("Block image")
+  internal func blockImage() throws {
     let markdown = try sut.markdown(
       fromHTML: "<img src=\"image.png\" alt=\"An image\">"
     )
-    XCTAssertEqual(markdown, "![An image](image.png)")
+    #expect(markdown == "![An image](image.png)")
   }
 
-  // MARK: Code blocks
+  // MARK: - Code blocks
 
-  internal func testCodeBlockLanguageFromClass() throws {
+  @Test("Code block language from class")
+  internal func codeBlockLanguageFromClass() throws {
     let html = "<pre><code class=\"language-swift\">let x = 1</code></pre>"
     let markdown = try sut.markdown(fromHTML: html)
     // Regression: language used to be hardcoded to "swift" regardless of input.
-    XCTAssertTrue(markdown.contains("```swift"), markdown)
-    XCTAssertTrue(markdown.contains("let x = 1"), markdown)
+    #expect(markdown.contains("```swift"))
+    #expect(markdown.contains("let x = 1"))
   }
 
-  internal func testCodeBlockWithoutLanguage() throws {
+  @Test("Code block without language")
+  internal func codeBlockWithoutLanguage() throws {
     let markdown = try sut.markdown(fromHTML: "<pre><code>plain text</code></pre>")
-    XCTAssertTrue(markdown.contains("plain text"), markdown)
-    XCTAssertTrue(markdown.contains("```"), markdown)
+    #expect(markdown.contains("plain text"))
+    #expect(markdown.contains("```"))
     // No language identifier should be emitted on the opening fence.
-    XCTAssertFalse(markdown.contains("```swift"), markdown)
+    #expect(!markdown.contains("```swift"))
   }
 
-  // MARK: Definition lists
+  // MARK: - Definition lists
 
-  internal func testDefinitionListRendersTermsAndDefinitions() throws {
+  @Test("Definition list renders terms and definitions")
+  internal func definitionListRendersTermsAndDefinitions() throws {
     let html = """
       <dl>
         <dt>package.json</dt>
@@ -102,13 +113,14 @@ internal final class SwiftSoupMarkdownGeneratorTests: XCTestCase {
       """
     let markdown = try sut.markdown(fromHTML: html)
     // Regression: <dl> used to be dropped entirely, losing all content.
-    XCTAssertTrue(markdown.contains("**package.json**"), markdown)
-    XCTAssertTrue(markdown.contains("for what node modules need to be installed"), markdown)
-    XCTAssertTrue(markdown.contains("**Gruntfile.js**"), markdown)
-    XCTAssertTrue(markdown.contains("the \"make\" file"), markdown)
+    #expect(markdown.contains("**package.json**"))
+    #expect(markdown.contains("for what node modules need to be installed"))
+    #expect(markdown.contains("**Gruntfile.js**"))
+    #expect(markdown.contains("the \"make\" file"))
   }
 
-  internal func testDefinitionListPreservesInlineFormattingInTerm() throws {
+  @Test("Definition list preserves inline formatting in term")
+  internal func definitionListPreservesInlineFormattingInTerm() throws {
     let html = """
       <dl>
         <dt><a href="http://nodejs.org/">NodeJS</a></dt>
@@ -116,11 +128,12 @@ internal final class SwiftSoupMarkdownGeneratorTests: XCTestCase {
       </dl>
       """
     let markdown = try sut.markdown(fromHTML: html)
-    XCTAssertTrue(markdown.contains("[NodeJS](http://nodejs.org/)"), markdown)
-    XCTAssertTrue(markdown.contains("for building the project"), markdown)
+    #expect(markdown.contains("[NodeJS](http://nodejs.org/)"))
+    #expect(markdown.contains("for building the project"))
   }
 
-  internal func testDefinitionListPreservesNestedBlockInDefinition() throws {
+  @Test("Definition list preserves nested block in definition")
+  internal func definitionListPreservesNestedBlockInDefinition() throws {
     let html = """
       <dl>
         <dt>Grunt</dt>
@@ -130,16 +143,17 @@ internal final class SwiftSoupMarkdownGeneratorTests: XCTestCase {
       </dl>
       """
     let markdown = try sut.markdown(fromHTML: html)
-    XCTAssertTrue(markdown.contains("**Grunt**"), markdown)
-    XCTAssertTrue(markdown.contains("install grunt globally"), markdown)
+    #expect(markdown.contains("**Grunt**"))
+    #expect(markdown.contains("install grunt globally"))
     // The nested code block inside the <dd> must survive.
-    XCTAssertTrue(markdown.contains("npm -g install grunt"), markdown)
-    XCTAssertTrue(markdown.contains("```bash"), markdown)
+    #expect(markdown.contains("npm -g install grunt"))
+    #expect(markdown.contains("```bash"))
   }
 
-  // MARK: Tables
+  // MARK: - Tables
 
-  internal func testLayoutTableFlattensCellContent() throws {
+  @Test("Layout table flattens cell content")
+  internal func layoutTableFlattensCellContent() throws {
     // Mailchimp newsletters wrap nearly all body content in layout tables.
     let html = """
       <table><tbody>
@@ -149,19 +163,21 @@ internal final class SwiftSoupMarkdownGeneratorTests: XCTestCase {
       """
     let markdown = try sut.markdown(fromHTML: html)
     // Regression: <table> used to be dropped, erasing the whole newsletter body.
-    XCTAssertTrue(markdown.contains("First cell"), markdown)
-    XCTAssertTrue(markdown.contains("Second cell"), markdown)
+    #expect(markdown.contains("First cell"))
+    #expect(markdown.contains("Second cell"))
   }
 
-  internal func testTablePreservesInlineFormattingAndLinks() throws {
+  @Test("Table preserves inline formatting and links")
+  internal func tablePreservesInlineFormattingAndLinks() throws {
     let html = """
       <table><tr><td><p>see <a href="https://example.com">the docs</a></p></td></tr></table>
       """
     let markdown = try sut.markdown(fromHTML: html)
-    XCTAssertTrue(markdown.contains("[the docs](https://example.com)"), markdown)
+    #expect(markdown.contains("[the docs](https://example.com)"))
   }
 
-  internal func testNestedTableContentEmittedExactlyOnce() throws {
+  @Test("Nested table content emitted exactly once")
+  internal func nestedTableContentEmittedExactlyOnce() throws {
     let html = """
       <table><tr><td>
         <table><tr><td><p>inner only</p></td></tr></table>
@@ -171,20 +187,22 @@ internal final class SwiftSoupMarkdownGeneratorTests: XCTestCase {
     let occurrences = markdown.components(separatedBy: "inner only").count - 1
     // Regression guard: descendant-cell selection must not double-emit nested
     // table content.
-    XCTAssertEqual(occurrences, 1, markdown)
+    #expect(occurrences == 1)
   }
 
-  // MARK: Stripped / empty content
+  // MARK: - Stripped / empty content
 
-  internal func testScriptAndIframeAreStripped() throws {
+  @Test("Script and iframe are stripped")
+  internal func scriptAndIframeAreStripped() throws {
     let html = "<p>keep</p><script>evil()</script><iframe src=\"x\"></iframe>"
     let markdown = try sut.markdown(fromHTML: html)
-    XCTAssertTrue(markdown.contains("keep"), markdown)
-    XCTAssertFalse(markdown.contains("evil"), markdown)
+    #expect(markdown.contains("keep"))
+    #expect(!markdown.contains("evil"))
   }
 
-  internal func testEmptyInput() throws {
-    XCTAssertEqual(try sut.markdown(fromHTML: ""), "")
-    XCTAssertEqual(try sut.markdown(fromHTML: "   "), "")
+  @Test("Empty input")
+  internal func emptyInput() throws {
+    #expect(try sut.markdown(fromHTML: "") == "")
+    #expect(try sut.markdown(fromHTML: "   ") == "")
   }
 }


### PR DESCRIPTION
Convert the XCTestCase suite (17 tests) to a single Swift Testing @Suite struct per the project's simple-suite convention (matches ButtondownClientTests): XCTAssert* -> #expect, test methods -> @Test, no XCTestCase class. Behavior and regression coverage unchanged; all 17 pass on the Swift 6.4 Linux toolchain.