### PR TITLE
ci: schedule automate-content to poll podcast & newsletter every 6h

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,6 +5,11 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ '*' ]
+  schedule:
+    # Every 6 hours at :05 (00:05 / 06:05 / 12:05 / 18:05 UTC) — poll for
+    # new podcast episodes and newsletters. The 5-minute offset avoids
+    # racing content published right on the hour boundary.
+    - cron: '5 */6 * * *'
   workflow_dispatch:
     inputs:
       automate_content:
@@ -52,7 +57,7 @@ jobs:
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
   automate-content:
-      if: ${{ inputs.automate_content != '' }}
+      if: ${{ github.event_name == 'schedule' || inputs.automate_content != '' }}
       needs: detect-changes
       runs-on: ubuntu-latest
       container:


### PR DESCRIPTION
Add a schedule trigger (cron '5 */6 * * *', four times a day at :05) and
broaden the automate-content job gate to fire on schedule events as well as
the manual workflow_dispatch input. The importers are already incremental and
idempotent, and the commit step is guarded on actual Content/ changes, so a
scheduled run with no new content is a clean no-op.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014z2E9UNgnWYDNsj2djGRxz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated content updates now run on a regular schedule throughout the day.
  * Manual runs continue to work as before, with improved support for both scheduled and ad hoc execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->