### PR TITLE
Reframe Phase 3 (AI-CITE) around evidence-backed levers

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -21,7 +21,7 @@ This document organizes all open GitHub issues into sequential phases and milest
 Phase 0 (housekeeping) ─────────────── independent, can run at any time
 Phase 1 (Monorepo cleanup) ──────────── prerequisite: [#36](https://github.com/brightdigit/brightdigit.com/issues/36) ✓ (complete)
 Phase 2 (Swift 6.3 main package) ────── requires Phase 1
-Phase 3 (AI-CITE schema + validation) ─ requires Phase 2 (intentional: implement after Swift 6.3 upgrade)
+Phase 3 (AI-CITE content optimization) ─ requires Phase 2 (intentional: implement after Swift 6.3 upgrade)
 Phase 4 (OpenAPI migration) ─────────── requires Phase 2 — Swift 6.3-only toolchain
 Phase 5 (Swift 6.3 subrepos + components) requires Phase 4
 Phase 6 (Publishing infra) ──────────── requires Phase 4 (swift-openapi-generator toolchain)
@@ -102,51 +102,46 @@ Phase 8 (Final cleanup) ─────────────── anytime, l
 
 ## Phase 3: AI-CITE Optimization
 
-**Milestone:** AI-CITE Phase 1 (target: Feb 28, 2026)  
-**Branch:** `ai-cite-optimization` (PR [#39](https://github.com/brightdigit/brightdigit.com/issues/39))  
-**Goal:** Implement structured schema markup and optimize priority articles so BrightDigit content is cited by AI systems (ChatGPT, Google AI Overview, etc.). AI-CITE is fundamentally an integration into the Swift site-building code (`PublishType` protocol + `BrightDigitSite` implementation) — not just article-level content edits. Intentionally sequenced after Phase 2 to avoid doing this work twice across a Swift 6.3 boundary.
+**Goal:** Get BrightDigit content cited by AI systems (ChatGPT, Claude, Perplexity, Google AI Overview) by optimizing content around the **evidence-backed** AI-citation levers, plus the small set of site-level tasks that support them. Sequenced after Phase 2 (Swift 6.3) so content/code work isn't redone across that boundary.
 
-**Framework:** AI-CITE — Answer-first, Intent-matched headings, Clear structure, Indexed schema, Trusted sources, Exclusive POV.  
-**Target:** 60% of priority articles get AI mentions within 1 week of optimization.
+> **⚠️ Evidence reframe (2026-07).** This phase was originally schema-markup-first (JSON-LD in `PiHTMLFactory`). The GEO Evidence Review in the `llm-ready-web` research repo ([`brightdigit/llm-ready-web`](https://github.com/brightdigit/llm-ready-web) `main`) — 300k+ domain studies + Google's own guidance — establishes that **schema/JSON-LD is not a proven AI-citation lever** (Google: *"there's no special schema.org markup you need to add"*; FAQ rich results deprecated 2023–24) and that **`llms.txt` has null effect**. The AI-CITE framework consequently **removed its "Indexed Schema" element**. The old schema issues (#19 FAQ, #20 HowTo, #56 schema-types, #18 seomachine.io) are **closed as `wontfix`**, and the retired `PiHTMLFactory` JSON-LD plan is gone. This phase now tracks the proven levers instead.
 
-### 3A: Schema Implementation
+**Framework:** AI-CITE (5 elements) — **A**nswer-first · **I**ntent-matched headings · **C**lear structure (lists/tables) · **T**rusted sources (citations) · **E**xclusive POV.
+**Proven levers (ranked):** citations/quotes/statistics (up to +40%) · answer-first placement (first third of page) · question-style headings · crawlability (the one technical must-have).
+**Target:** 6/10 priority queries surface a BrightDigit mention within 2–3 weeks of optimization (source-reported "60% in a week" is a directional target, not independently verified).
 
-| # | Title | Priority | Status |
-|---|-------|----------|--------|
-| [#56](https://github.com/brightdigit/brightdigit.com/issues/56) | Evaluate correct schema.org types for each content section | P0-critical | Open |
-| [#18](https://github.com/brightdigit/brightdigit.com/issues/18) | Add seomachine.io integration | P1-high | Open |
-| [#19](https://github.com/brightdigit/brightdigit.com/issues/19) | Implement FAQ Schema Markup in `PiHTMLFactory` | P0-critical | In Progress |
-| [#20](https://github.com/brightdigit/brightdigit.com/issues/20) | Implement HowTo Schema Markup in `PiHTMLFactory` | P1-high | Open |
+### 3A: Content optimization (per-article — the proven levers)
 
-**Note:** [#56](https://github.com/brightdigit/brightdigit.com/issues/56) must be resolved before [#19](https://github.com/brightdigit/brightdigit.com/issues/19) and [#20](https://github.com/brightdigit/brightdigit.com/issues/20) — schema type selection drives the implementation.
-
-**Implementation files:**
-- `Sources/PublishType/PageContent.swift` — add `schemaMarkup: String?` requirement (`PublishType` owns the protocol contract)
-- `Sources/BrightDigitSite/Nodes/PiHTMLFactory.HTML.swift` — `head(forPage:)` emits `<script type="application/ld+json">` when `schemaMarkup` is non-nil
-- `Sources/BrightDigitSite/PiHTMLFactory.swift` — main factory (not a protocol)
-- `Sources/BrightDigitSite/BrightDigitSite.swift` — extend `ItemMetadata` with `faqItems: [FAQItem]?`, `howToSteps: [HowToStep]?`
-- Each `Sources/BrightDigitSite/Nodes/Section/*.swift` — implement `schemaMarkup` (the `BrightDigitSite` layer provides the concrete values)
-
-**Integration architecture:**
-- `PublishType` defines the requirement; `BrightDigitSite` types fulfill it — consistent with the existing layering throughout the codebase
-- Adding `schemaMarkup: String?` to `PageContent` is additive and does not conflict with the Phase 5 component migration (which rewrites how content is built, not the protocol shape)
-- Schema types per section (auto-generated from existing metadata unless noted):
-  - Articles → `Article` (title, description, date, featuredImage — zero new front matter)
-  - Tutorials → `HowTo` (requires `howToSteps` front matter array, or extracted from `##` headings)
-  - Products → `SoftwareApplication` (platforms, technologies, appStoreURL, githubRepoName)
-  - FAQ pages → `FAQPage` (requires `faqItems` front matter array)
-  - Index / About-Us → `Organization` (hardcoded BrightDigit metadata)
-- The `.claude/ai-cite-optimization/` docs already define `FAQSchema`, `HowToSchema`, `ArticleSchema`, `Person`, `Organization`, `ImageObject` structures — wire these to the Swift build
-
-**Note:** FAQ and HowTo schemas are most valuable for AI citations. `Article` and `SoftwareApplication` schemas provide additional richness at zero content-authoring cost since all required fields already exist in `ItemMetadata`.
-
-### 3B: Validation
+Answer-first rewrites, question-style headings, comparison tables, and authoritative citations on the priority "money articles." Moved into Phase 3 from the former "Post-Migration: Content & Articles" milestone (the schema dependency gate is gone, so these are immediately actionable).
 
 | # | Title | Priority | Status |
 |---|-------|----------|--------|
-| [#23](https://github.com/brightdigit/brightdigit.com/issues/23) | Test AI-CITE Baseline and Validate Schema | P1-high | Open |
+| [#21](https://github.com/brightdigit/brightdigit.com/issues/21) | Optimize Mise Setup Guide for AI-CITE | P1-high | Open |
+| [#22](https://github.com/brightdigit/brightdigit.com/issues/22) | Optimize Best Backend Article for AI-CITE | P1-high | Open |
+| [#26](https://github.com/brightdigit/brightdigit.com/issues/26) | Optimize iOS CI/CD Article for AI-CITE | P1-high | Open |
+| [#27](https://github.com/brightdigit/brightdigit.com/issues/27) | Optimize iOS Architecture Article for AI-CITE | P1-high | Open |
+| [#28](https://github.com/brightdigit/brightdigit.com/issues/28) | Optimize Remaining Priority Articles (Batch) | P1-high | Open |
+| [#130](https://github.com/brightdigit/brightdigit.com/issues/130) | Split `dependency-management-swift` into two answer-first pages | P1-high | Open |
 
-**Reference:** `.claude/ai-cite-optimization/`
+### 3B: Site-level tasks
+
+| # | Title | Priority | Status |
+|---|-------|----------|--------|
+| [#129](https://github.com/brightdigit/brightdigit.com/issues/129) | Fix misleading freshness signal: real publish/`dateModified` dates sitewide | P0-critical | Open |
+| [#131](https://github.com/brightdigit/brightdigit.com/issues/131) | Add `robots.txt` with a `Sitemap:` line | P2-medium | Open |
+| [#132](https://github.com/brightdigit/brightdigit.com/issues/132) | Normalize brand name ("BrightDigit") sitewide | P2-medium | Open |
+
+**#129 is the one surviving `PiHTMLFactory` code task:** the footer at `Sources/BrightDigitSite/Nodes/Node+HTML.swift:187-191` renders `.year()` (current build year) as a false freshness signal; replace it and surface real per-page dates (`item.metadata.date` already exists across `Nodes/Section/*`). Crawlability is otherwise good (server-rendered, `index,follow` meta emitted, valid sitemap); #131 just adds the `Sitemap:` pointer.
+
+### 3C: Measurement
+
+| # | Title | Priority | Status |
+|---|-------|----------|--------|
+| [#23](https://github.com/brightdigit/brightdigit.com/issues/23) | Establish AI-citation baseline test | P1-high | Open |
+
+Run the 10-query baseline (ChatGPT/Claude/Perplexity + Google AI Overview) **before** the content work lands, then re-test weekly. No schema validation.
+
+**Reference:** `brightdigit/llm-ready-web` `main` — `resources/geo-evidence-review.md`, `resources/ai-cite-framework.md`, `case-studies/brightdigit-ai-cite/`.
 
 ---
 
@@ -202,7 +197,7 @@ Phase 8 (Final cleanup) ─────────────── anytime, l
 
 **Plot API context:** Plot has two coexisting APIs. The **Node API** (`Node<HTML.BodyContext>`) is lower-level and functional — used throughout `Nodes/`. The **Component API** (`Component` protocol, SwiftUI-style `var body: Component`) is declarative and already used in `Components/` (SectionElement, ServiceBox, Icon, ListItem) and in `ServicesBuilder.swift` and `ProductItem.swift`. Nodes conform to `Component`; components bridge back via `.convertToNode()`.
 
-**Migration approach:** Keep `PageContent.main` as `[Node<HTML.BodyContext>]`; leaf components call `.convertToNode()` at the boundary. This matches the pattern already established in `ProductItem.swift` and avoids a `PageContent` protocol break. The `schemaMarkup: String?` property added to `PageContent` in Phase 3 carries forward unchanged.
+**Migration approach:** Keep `PageContent.main` as `[Node<HTML.BodyContext>]`; leaf components call `.convertToNode()` at the boundary. This matches the pattern already established in `ProductItem.swift` and avoids a `PageContent` protocol break. (The `schemaMarkup: String?` property once planned for Phase 3 is no longer being added — the schema work was retired in the 2026-07 evidence reframe — so there is nothing extra to carry through this migration.)
 
 **Migration order:** (1) header/footer in `PiHTMLFactory.HTML.swift` (affects every page), (2) `Nodes/Section/` item content files, (3) `Nodes/Pages/` builders.
 
@@ -316,7 +311,7 @@ New source modules (local to this repo, not subrepos):
 
 ## Post-Migration Content Tasks
 
-**Goal:** Pure content edits and article optimization — no code changes required. Deferred until the schema pipeline (Phase 3A + Swift migration) is stable.
+**Goal:** Pure content edits — no code changes required. (The AI-CITE **article optimization** issues formerly listed here — #21/#22/#26/#27/#28 — moved into **Phase 3** as part of the 2026-07 evidence reframe; see Phase 3 §3A.)
 
 **Note:** Apply the `article-edit` GitHub label to all issues below to distinguish from migration/code issues.
 
@@ -327,18 +322,6 @@ New source modules (local to this repo, not subrepos):
 | [#3](https://github.com/brightdigit/brightdigit.com/issues/3) | Add Additional Local Storage Options | Open |
 | [#4](https://github.com/brightdigit/brightdigit.com/issues/4) | Add Main Actor to Swift 6 Article Solution | Open |
 | [#13](https://github.com/brightdigit/brightdigit.com/issues/13) | Clarify String vs Reference design choice in MistKit article | Open |
-
-### Article Optimization (formerly Phase 1B)
-
-| # | Title | Priority | Status |
-|---|-------|----------|--------|
-| [#21](https://github.com/brightdigit/brightdigit.com/issues/21) | Optimize Mise Setup Guide for AI-CITE | P1-high | Open |
-| [#22](https://github.com/brightdigit/brightdigit.com/issues/22) | Optimize Best Backend Article for AI-CITE | P1-high | Open |
-| [#26](https://github.com/brightdigit/brightdigit.com/issues/26) | Optimize iOS CI/CD Article for AI-CITE | P1-high | Open |
-| [#27](https://github.com/brightdigit/brightdigit.com/issues/27) | Optimize iOS Architecture Article for AI-CITE | P1-high | Open |
-| [#28](https://github.com/brightdigit/brightdigit.com/issues/28) | Optimize Remaining Priority Articles (Batch) | P1-high | Open |
-
-**Dependency:** Phase 3A ([#19](https://github.com/brightdigit/brightdigit.com/issues/19) schema implementation) must be complete and stable before article optimization begins.
 
 ---
 
@@ -357,11 +340,11 @@ New source modules (local to this repo, not subrepos):
 | Phase 0 | 2 | Quick wins |
 | Phase 1 | 0 | Monorepo cleanup ([#36](https://github.com/brightdigit/brightdigit.com/issues/36) already done; MarkdownGenerator removal folded into Phase 4 [#40](https://github.com/brightdigit/brightdigit.com/issues/40); [#47](https://github.com/brightdigit/brightdigit.com/issues/47) retitled and moved to Phase 4) |
 | Phase 2 | 4 | Swift 6.3 main package + lint config ([#54](https://github.com/brightdigit/brightdigit.com/issues/54)) + CI cache ([#65](https://github.com/brightdigit/brightdigit.com/issues/65)) + rebuild-avoidance (TBD) |
-| Phase 3 | 5 | AI-CITE schema ([#56](https://github.com/brightdigit/brightdigit.com/issues/56), [#18](https://github.com/brightdigit/brightdigit.com/issues/18), [#19](https://github.com/brightdigit/brightdigit.com/issues/19), [#20](https://github.com/brightdigit/brightdigit.com/issues/20)) + validation ([#23](https://github.com/brightdigit/brightdigit.com/issues/23)) |
+| Phase 3 | 10 | AI-CITE content optimization (evidence reframe): articles [#21](https://github.com/brightdigit/brightdigit.com/issues/21)/[#22](https://github.com/brightdigit/brightdigit.com/issues/22)/[#26](https://github.com/brightdigit/brightdigit.com/issues/26)/[#27](https://github.com/brightdigit/brightdigit.com/issues/27)/[#28](https://github.com/brightdigit/brightdigit.com/issues/28) + split [#130](https://github.com/brightdigit/brightdigit.com/issues/130); site-level dates [#129](https://github.com/brightdigit/brightdigit.com/issues/129)/robots [#131](https://github.com/brightdigit/brightdigit.com/issues/131)/brand [#132](https://github.com/brightdigit/brightdigit.com/issues/132); baseline [#23](https://github.com/brightdigit/brightdigit.com/issues/23). Schema issues #19/#20/#56/#18 **closed as wontfix** |
 | Phase 4 | 7 | OpenAPI migration + Kanna → SwiftSoup ([#47](https://github.com/brightdigit/brightdigit.com/issues/47)) |
 | Phase 5 | 5 | Swift 6.3 subrepos + components + Tailwind (TBD) + AI-CITE content strategy ([#24](https://github.com/brightdigit/brightdigit.com/issues/24), [#25](https://github.com/brightdigit/brightdigit.com/issues/25)) |
 | Phase 6 | 5 | Publishing infrastructure + AT Protocol ([#49](https://github.com/brightdigit/brightdigit.com/issues/49)) feeds Buffer |
 | Phase 7 | 2 | Platform migration + form integration (TBD) |
 | Phase 8 | 3 | Deferred cleanup |
-| Post-Migration | 8 | Article edits ([#3](https://github.com/brightdigit/brightdigit.com/issues/3), [#4](https://github.com/brightdigit/brightdigit.com/issues/4), [#13](https://github.com/brightdigit/brightdigit.com/issues/13)) + article optimization ([#21](https://github.com/brightdigit/brightdigit.com/issues/21), [#22](https://github.com/brightdigit/brightdigit.com/issues/22), [#26](https://github.com/brightdigit/brightdigit.com/issues/26), [#27](https://github.com/brightdigit/brightdigit.com/issues/27), [#28](https://github.com/brightdigit/brightdigit.com/issues/28)) |
-| **Total** | **41** | Excludes [#12](https://github.com/brightdigit/brightdigit.com/issues/12) (done), [#36](https://github.com/brightdigit/brightdigit.com/issues/36) (done), [#43](https://github.com/brightdigit/brightdigit.com/issues/43) (dropped); includes 3 TBD issues awaiting GitHub creation (Phase 2 rebuild-avoidance, Phase 5 Tailwind, Phase 7 form integration) |
+| Post-Migration | 3 | Article edits ([#3](https://github.com/brightdigit/brightdigit.com/issues/3), [#4](https://github.com/brightdigit/brightdigit.com/issues/4), [#13](https://github.com/brightdigit/brightdigit.com/issues/13)); article-optimization issues moved to Phase 3 |
+| **Total** | **41** | Excludes [#12](https://github.com/brightdigit/brightdigit.com/issues/12) (done), [#36](https://github.com/brightdigit/brightdigit.com/issues/36) (done), [#43](https://github.com/brightdigit/brightdigit.com/issues/43) (dropped), and the 4 schema issues [#19](https://github.com/brightdigit/brightdigit.com/issues/19)/[#20](https://github.com/brightdigit/brightdigit.com/issues/20)/[#56](https://github.com/brightdigit/brightdigit.com/issues/56)/[#18](https://github.com/brightdigit/brightdigit.com/issues/18) (closed wontfix, 2026-07); Phase 3 gained 4 new issues ([#129](https://github.com/brightdigit/brightdigit.com/issues/129)–[#132](https://github.com/brightdigit/brightdigit.com/issues/132)) — net unchanged. Includes 3 TBD issues awaiting GitHub creation (Phase 2 rebuild-avoidance, Phase 5 Tailwind, Phase 7 form integration) |

--- a/docs/content-ops-plan.md
+++ b/docs/content-ops-plan.md
@@ -1,0 +1,127 @@
+# Content-Planning Infrastructure — Proposed Issue Set
+
+**Status:** Draft for review · **Target repo:** `brightdigit/brightdigit.com` · **2026-07**
+
+## Context
+
+`leogdion/year-in-review` (private) is the planning/draft hub for all BrightDigit/EmpowerApps
+content — articles, podcast episodes, newsletters, multi-platform social posts, and talks. It
+already has a mature-but-ad-hoc system: content organized by medium, YAML front matter with a
+hand-authored `related:` graph, a `/content-topic-mining` skill, per-platform voice guides, and
+three content pillars (AI+Swift, Opinion/Reflection, OSS Releases). It already links to **live
+brightdigit.com URLs** (e.g. a social clip's `related.episode:
+https://brightdigit.com/episodes/209-…/`), and newsletters are Buttondown-markdown-native.
+
+**The gap:** there is no *defined, executable infrastructure* that lets Claude Code **guide** future
+content across every medium/platform **without writing full drafts**. Today the cross-media fan-out
+is inferred from matching filenames + a drifting `related:` vocabulary; there is no canonical
+"topic" record; status tracking is duplicated and manual; and none of it is connected to the Swift
+program that actually renders and publishes the public site.
+
+The public site (`brightdigit.com`) is a Swift Publish static-site generator: five sections
+(`articles`/`episodes`/`tutorials`/`newsletters`/`products`), one `Codable` metadata struct
+(`BrightDigitSite.ItemMetadata`) that the pipeline decodes from front matter and that the renderer
+plus the future fan-out consume. "Draft" today = future-dated only (no `draft:` flag). Phase 6 will
+add `PublishKit`/`ButtondownKit`/`BufferKit`/`ATProtoKit` for newsletter + social fan-out. A future
+refactor will separate `Content/*.md` from `Sources/*.swift` — the front-matter↔Swift-struct
+contract is unchanged by that split.
+
+**Goal:** define the GitHub issues (in `brightdigit.com`) that build a content-planning /
+scaffolding infrastructure, aligned to the existing migration phases.
+
+## Design decisions
+
+1. **Deliverables (all four):** canonical topic entity · per-medium/platform briefs · unified
+   cross-media link schema · a `/content-plan` skill.
+2. **Coupling:** build the **planning layer now**; wire publish/fan-out **later** (do not block on
+   unbuilt Phase 6 modules).
+3. **Phase fit — split:** schema + spec-generator + briefs + skill → **Phase 3 (content)**;
+   publish/fan-out wiring → **Phase 6 (publishing infra)**.
+4. **Schema is Swift-first, spec is derived.** The authoritative contract is the Swift metadata
+   types (`PublishType` / `ItemMetadata`) — the fields the renderer and fan-out require, because the
+   Swift program is what renders HTML and publishes/fans out. **No hand-maintained spec doc.**
+   Instead a generator (a skill, or a `/content-plan` sub-step) **parses the latest Swift type and
+   emits the companion spec on the fly** — an easy "pull latest Swift file → produce current spec"
+   path. The private repo and the skill consume that generated spec.
+5. **Skill is portable:** a self-contained `/content-plan` skill package (+ voice/pillar/platform
+   guides) usable from **both** repos.
+6. **Topic entity is private-only for now:** the topic/campaign record is a first-class entity, but
+   its records live **only in year-in-review**. brightdigit.com published items carry only the
+   cross-media **link fields**; the public site never hosts topic records.
+
+## Proposed issues
+
+Ordering: **I1** (link-field schema) is foundational — the generator (I2), briefs (I4), and skill
+(I5) all consume it. **I6** (fan-out) is Phase 6 and depends on the Phase 3 pieces landing.
+
+### Phase 3 — planning layer (schema, spec, briefs, skill)
+
+#### I1 — Cross-media link schema on published items (Swift types) · P1-high
+Extend `BrightDigitSite.ItemMetadata` (`Sources/BrightDigitSite/BrightDigitSite.swift`) and the
+`PublishType` protocol layer (`Sources/PublishType/`) with a **unified, validated cross-media link
+vocabulary**, replacing the drifting free-text `related.social` / `related.newsletter` /
+`related.episode`. Fields let a published site item declare its topic slug and cross-media siblings
+(e.g. `topicSlug`, `sourceRef`, `related.{episode,newsletter,social,article,talk,video}`). Codable,
+optional, additive (does not break existing content). This is the **contract** the renderer and the
+future fan-out read.
+*Coordinate with the Phase-5 component migration — additive fields on `ItemMetadata` don't conflict
+(same rationale the PRD uses for `schemaMarkup`).*
+Labels: `enhancement`.
+
+#### I2 — Swift-type → companion-spec generator · P1-high · depends on I1
+A capability (standalone skill, or a sub-step invoked by `/content-plan`) that **reads the latest
+`ItemMetadata` / `PublishType` Swift source and emits a current, human/machine-readable companion
+spec** (fields, types, link vocabulary). No hand-maintained schema doc — always derived from the
+authoritative Swift types via an easy "pull latest → generate spec" path. Output is what the private
+repo drafts and the briefs/skill validate against.
+Labels: `enhancement`, `documentation`.
+
+#### I3 — Canonical topic-entity definition (private-only records) · P2-medium · relates to I1
+Define the topic/campaign entity: id/slug, source (repo/PR/episode/release), status, and the fan-out
+map (which media + platforms it spawns). Specify it as a **type/shape** so records are consistent,
+but its **records live only in year-in-review** — brightdigit.com hosts the *definition* + the link
+fields (I1), not topic records. Documents how a topic threads mining → briefs → per-platform drafts
+→ published items.
+Labels: `documentation`, `enhancement`.
+
+#### I4 — Per-medium/platform content briefs (scaffolds, not drafts) · P1-high · depends on I1, I2
+Templates/scaffolds per medium+platform (article, tutorial, episode clip, newsletter, and
+Twitter/LinkedIn/Mastodon/YouTube/Patreon variants): hook, angle, key points, CTA, length, voice,
+links — **structured guidance, not full copy**. Encodes the voice/pillar/platform guides distilled
+from year-in-review (`social-posts/README.md`, `newsletters/README.md`,
+`planning/content-strategy-2026.md`). Conforms to the I1 fields / I2 spec.
+Labels: `documentation`.
+
+#### I5 — Portable `/content-plan` skill · P1-high · depends on I1, I2, I4
+A self-contained skill package usable from both repos. Input: a source (mining hit / episode /
+release / PR). Output: a topic record (I3 shape) + per-medium/platform briefs (I4), enforcing the
+pillars and voice/platform guides and emitting front matter conformant to the I1 fields (validated
+via the I2-generated spec). Complements the existing `/content-topic-mining` skill (mining → this →
+briefs). **Writes guidance, never final long-form copy.**
+Labels: `enhancement`.
+
+### Phase 6 — publish / fan-out wiring (later)
+
+#### I6 — Wire the content plan to the publish + fan-out pipeline · P1-high · depends on I1–I5, #33/#31/#30/#49
+Consume the I1 link fields / topic plan to drive fan-out once Phase 6 modules exist: newsletter via
+`ButtondownKit`, social via `BufferKit`/`ATProtoKit`, site items via the Publish pipeline + the
+future-date "draft" mechanism. Turns a planned topic into scheduled/published outputs across media.
+Labels: `enhancement`.
+
+## Alignment notes
+
+- **Phase 3** currently holds the evidence-backed content-optimization work (PR #133 reframe:
+  articles + site tasks + baseline). The planning-infra issues (I1–I5) fit its "content" theme.
+- **Phase 6** holds the publishing architecture (`#33` umbrella, `#31` newsletters, `#30` Buffer,
+  `#49` AT). I6 slots there and depends on them.
+- House style: dependency links as `Depends on:` / `Related:` body lines; reuse existing labels
+  (`enhancement`, `documentation`, `P0/P1/P2-*`); milestone via `-m`.
+- **Refactor-proof:** the schema is front-matter fields on a Codable Swift struct — the future
+  `Content/` ↔ `Sources/` split changes *where files live*, not the field contract, so I1's fields
+  travel with the content unchanged.
+
+## Open sequencing question
+
+Whether to group I1–I5 under a **new "Content Ops" milestone** vs. folding into Phase 3 was raised;
+current choice is the **split (Phase 3 + Phase 6)**. If Phase 3 gets crowded, revisit a dedicated
+milestone at execution time.


### PR DESCRIPTION
## Summary

Re-aligns the **Phase 3: AI-CITE Optimization** milestone to the updated GEO evidence in the [`brightdigit/llm-ready-web`](https://github.com/brightdigit/llm-ready-web) research repo (`main`). The GEO Evidence Review (300k+ domain studies + Google's own guidance) establishes that **schema/JSON-LD is not a proven AI-citation lever** and **`llms.txt` has null effect**; the AI-CITE framework consequently **dropped its "Indexed Schema" element** (now 5 elements: **A**nswer-first, **I**ntent-matched headings, **C**lear structure, **T**rusted sources, **E**xclusive POV).

Phase 3 was previously 100% schema/tooling work. This PR is the **PRD sync**; the GitHub issue surgery below is already applied to the issues.

## Issue surgery (already live)

**Closed as `wontfix`** (debunked premise): #19 (FAQ schema), #20 (HowTo schema), #56 (evaluate schema types), #18 (seomachine.io).

**Reframed:** #23 "Test AI-CITE Baseline and Validate Schema" → **"Establish AI-citation baseline test"** (dropped schema validation; expanded to ChatGPT/Claude/Perplexity + AI Overview).

**Moved into Phase 3** (the proven-lever content work, from "Post-Migration"): #21, #22, #26, #27, #28. Stripped stale "HowTo schema" lines from #21/#26.

**Created in Phase 3:**
- #129 — Fix misleading freshness signal: real publish/`dateModified` dates sitewide (**P0**). Footer renders `.year()` = build year at `Node+HTML.swift:187-191`.
- #130 — Split `dependency-management-swift` into two answer-first pages (**P1**).
- #131 — Add `robots.txt` with a `Sitemap:` line (**P2**).
- #132 — Normalize brand name ("BrightDigit") sitewide (**P2**).

## PRD changes in this PR

- Phase 3 rewritten: 5-element framework; schema subsection removed; new §3A content optimization / §3B site-level / §3C measurement tables; proven-lever ranking.
- Removed the "Phase 3A schema must be complete before article optimization" dependency gate.
- Dependency-chain graph + issue-count summary updated; stale Phase 5 `schemaMarkup` carry-forward note corrected.

## Resulting Phase 3

Baseline test (#23) · 5 article optimizations (#21/#22/#26/#27/#28) · dependency-split (#130) · footer/dates (#129) · robots.txt (#131) · brand (#132). Schema issues closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the planning docs to reflect a new evidence-based content strategy, shifting focus to citations, quotes, statistics, stronger answer-first structure, question-style headings, and better crawlability.
  * Revised the roadmap, timing, and measurement approach, and clarified which article and site-level improvements are now prioritized.
* **Chores**
  * Cleaned up phase breakdowns and issue counts to match the new plan, including moving some items into earlier work and marking outdated schema-related work as no longer planned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->