### PR TITLE
Add content-planning infrastructure proposal + Phase 3 (AI-CITE) / Phase 5 roadmap updates

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -23,11 +23,24 @@ Phase 1 (Monorepo cleanup) ──────────── prerequisite: [#
 Phase 2 (Swift 6.3 main package) ────── requires Phase 1
 Phase 3 (AI-CITE schema + validation) ─ requires Phase 2 (intentional: implement after Swift 6.3 upgrade)
 Phase 4 (OpenAPI migration) ─────────── requires Phase 2 — Swift 6.3-only toolchain
-Phase 5 (Swift 6.3 subrepos + components) requires Phase 4
+Phase 5 (Swift 6.3 subrepos + components) requires Phase 4  [+ high-priority Buttondown email work pulled forward — see note]
 Phase 6 (Publishing infra) ──────────── requires Phase 4 (swift-openapi-generator toolchain)
 Phase 7 (Platform migration) ────────── requires Phase 5/6
 Phase 8 (Final cleanup) ─────────────── anytime, low priority
 ```
+
+> **Note (Buttondown priority):** Phase 5 and Phase 6 are siblings — both require only Phase 4,
+> neither requires the other. Because the Buttondown newsletter/email work is now high priority,
+> the email-import + hosted-HTML-cleanup chain ([#124](https://github.com/brightdigit/brightdigit.com/issues/124)
+> → [#122](https://github.com/brightdigit/brightdigit.com/issues/122),
+> [#127](https://github.com/brightdigit/brightdigit.com/issues/127)) and the subscribe form
+> ([#126](https://github.com/brightdigit/brightdigit.com/issues/126)) have been pulled forward
+> into **Phase 5** to run concurrently with the component migration. The outbound publishing leg
+> ([#33](https://github.com/brightdigit/brightdigit.com/issues/33),
+> [#31](https://github.com/brightdigit/brightdigit.com/issues/31)) and social/video
+> ([#30](https://github.com/brightdigit/brightdigit.com/issues/30),
+> [#32](https://github.com/brightdigit/brightdigit.com/issues/32),
+> [#49](https://github.com/brightdigit/brightdigit.com/issues/49)) remain in Phase 6.
 
 ---
 
@@ -218,6 +231,15 @@ Phase 8 (Final cleanup) ─────────────── anytime, l
 | [#24](https://github.com/brightdigit/brightdigit.com/issues/24) | YouTube Video Content Strategy | Open |
 | [#25](https://github.com/brightdigit/brightdigit.com/issues/25) | Create Unique BrightDigit Frameworks/Methodologies | Open |
 
+**Buttondown newsletter/email work (pulled forward from Phase 6 — high priority; sibling phase, both gated only on Phase 4):**
+
+| # | Title | Priority | Status |
+|---|-------|----------|--------|
+| [#124](https://github.com/brightdigit/brightdigit.com/issues/124) | ButtondownClient: expose `listEmails` (paged) | P0-critical | Open — foundational; blocks #122, #127 |
+| [#122](https://github.com/brightdigit/brightdigit.com/issues/122) | Import published newsletters from Buttondown (`import buttondown`) | P1-high | Open — blocked by #124; new issues only |
+| [#127](https://github.com/brightdigit/brightdigit.com/issues/127) | Fix HTML of MailChimp-imported emails hosted in Buttondown (REST API) | P1-high | Open — needs #124 + `updateEmail` wrapper |
+| [#126](https://github.com/brightdigit/brightdigit.com/issues/126) | Point subscribe form at Buttondown | P1-high | Open — decoupled from the component migration (uses Plot static factories, not the `Node()` init restricted by #53) |
+
 **Swift 6.3 subrepo upgrades (17 total):**
 - Publish ecosystem (8): Publish, Plot, Files, Codextended, Sweep, CollectionConcurrencyKit, Splash, SplashPublishPlugin
 - BrightDigit packages (7): SwiftTube 2.0.0, Spinetail 2.0.0, SyndiKit 1.0.0, NPMPublishPlugin, Contribute 2.0.0, ContributeWordPress, TransistorPublishPlugin
@@ -256,6 +278,14 @@ Phase 8 (Final cleanup) ─────────────── anytime, l
 **Goal:** Replace the Mailchimp-based newsletter workflow with a Buttondown + Buffer Swift CLI. Enable video podcast publishing.
 
 **Dependency:** Phase 4 (swift-openapi-generator toolchain available).
+
+> **Moved to Phase 5:** The inbound email-import + hosted-HTML-cleanup chain
+> ([#124](https://github.com/brightdigit/brightdigit.com/issues/124),
+> [#122](https://github.com/brightdigit/brightdigit.com/issues/122),
+> [#127](https://github.com/brightdigit/brightdigit.com/issues/127)) and the subscribe form
+> ([#126](https://github.com/brightdigit/brightdigit.com/issues/126)) were pulled forward into
+> Phase 5 as high-priority Buttondown work. This phase retains the **outbound** publishing leg
+> and social/video below.
 
 | # | Title | Status |
 |---|-------|--------|

--- a/PRD.md
+++ b/PRD.md
@@ -21,7 +21,7 @@ This document organizes all open GitHub issues into sequential phases and milest
 Phase 0 (housekeeping) ─────────────── independent, can run at any time
 Phase 1 (Monorepo cleanup) ──────────── prerequisite: [#36](https://github.com/brightdigit/brightdigit.com/issues/36) ✓ (complete)
 Phase 2 (Swift 6.3 main package) ────── requires Phase 1
-Phase 3 (AI-CITE schema + validation) ─ requires Phase 2 (intentional: implement after Swift 6.3 upgrade)
+Phase 3 (AI-CITE content optimization) ─ requires Phase 2 (intentional: implement after Swift 6.3 upgrade)
 Phase 4 (OpenAPI migration) ─────────── requires Phase 2 — Swift 6.3-only toolchain
 Phase 5 (Swift 6.3 subrepos + components) requires Phase 4
 Phase 6 (Publishing infra) ──────────── requires Phase 4 (swift-openapi-generator toolchain)
@@ -102,51 +102,46 @@ Phase 8 (Final cleanup) ─────────────── anytime, l
 
 ## Phase 3: AI-CITE Optimization
 
-**Milestone:** AI-CITE Phase 1 (target: Feb 28, 2026)  
-**Branch:** `ai-cite-optimization` (PR [#39](https://github.com/brightdigit/brightdigit.com/issues/39))  
-**Goal:** Implement structured schema markup and optimize priority articles so BrightDigit content is cited by AI systems (ChatGPT, Google AI Overview, etc.). AI-CITE is fundamentally an integration into the Swift site-building code (`PublishType` protocol + `BrightDigitSite` implementation) — not just article-level content edits. Intentionally sequenced after Phase 2 to avoid doing this work twice across a Swift 6.3 boundary.
+**Goal:** Get BrightDigit content cited by AI systems (ChatGPT, Claude, Perplexity, Google AI Overview) by optimizing content around the **evidence-backed** AI-citation levers, plus the small set of site-level tasks that support them. Sequenced after Phase 2 (Swift 6.3) so content/code work isn't redone across that boundary.
 
-**Framework:** AI-CITE — Answer-first, Intent-matched headings, Clear structure, Indexed schema, Trusted sources, Exclusive POV.  
-**Target:** 60% of priority articles get AI mentions within 1 week of optimization.
+> **⚠️ Evidence reframe (2026-07).** This phase was originally schema-markup-first (JSON-LD in `PiHTMLFactory`). The GEO Evidence Review in the `llm-ready-web` research repo ([`brightdigit/llm-ready-web`](https://github.com/brightdigit/llm-ready-web) `main`) — 300k+ domain studies + Google's own guidance — establishes that **schema/JSON-LD is not a proven AI-citation lever** (Google: *"there's no special schema.org markup you need to add"*; FAQ rich results deprecated 2023–24) and that **`llms.txt` has null effect**. The AI-CITE framework consequently **removed its "Indexed Schema" element**. The old schema issues (#19 FAQ, #20 HowTo, #56 schema-types, #18 seomachine.io) are **closed as `wontfix`**, and the retired `PiHTMLFactory` JSON-LD plan is gone. This phase now tracks the proven levers instead.
 
-### 3A: Schema Implementation
+**Framework:** AI-CITE (5 elements) — **A**nswer-first · **I**ntent-matched headings · **C**lear structure (lists/tables) · **T**rusted sources (citations) · **E**xclusive POV.
+**Proven levers (ranked):** citations/quotes/statistics (up to +40%) · answer-first placement (first third of page) · question-style headings · crawlability (the one technical must-have).
+**Target:** 6/10 priority queries surface a BrightDigit mention within 2–3 weeks of optimization (source-reported "60% in a week" is a directional target, not independently verified).
 
-| # | Title | Priority | Status |
-|---|-------|----------|--------|
-| [#56](https://github.com/brightdigit/brightdigit.com/issues/56) | Evaluate correct schema.org types for each content section | P0-critical | Open |
-| [#18](https://github.com/brightdigit/brightdigit.com/issues/18) | Add seomachine.io integration | P1-high | Open |
-| [#19](https://github.com/brightdigit/brightdigit.com/issues/19) | Implement FAQ Schema Markup in `PiHTMLFactory` | P0-critical | In Progress |
-| [#20](https://github.com/brightdigit/brightdigit.com/issues/20) | Implement HowTo Schema Markup in `PiHTMLFactory` | P1-high | Open |
+### 3A: Content optimization (per-article — the proven levers)
 
-**Note:** [#56](https://github.com/brightdigit/brightdigit.com/issues/56) must be resolved before [#19](https://github.com/brightdigit/brightdigit.com/issues/19) and [#20](https://github.com/brightdigit/brightdigit.com/issues/20) — schema type selection drives the implementation.
-
-**Implementation files:**
-- `Sources/PublishType/PageContent.swift` — add `schemaMarkup: String?` requirement (`PublishType` owns the protocol contract)
-- `Sources/BrightDigitSite/Nodes/PiHTMLFactory.HTML.swift` — `head(forPage:)` emits `<script type="application/ld+json">` when `schemaMarkup` is non-nil
-- `Sources/BrightDigitSite/PiHTMLFactory.swift` — main factory (not a protocol)
-- `Sources/BrightDigitSite/BrightDigitSite.swift` — extend `ItemMetadata` with `faqItems: [FAQItem]?`, `howToSteps: [HowToStep]?`
-- Each `Sources/BrightDigitSite/Nodes/Section/*.swift` — implement `schemaMarkup` (the `BrightDigitSite` layer provides the concrete values)
-
-**Integration architecture:**
-- `PublishType` defines the requirement; `BrightDigitSite` types fulfill it — consistent with the existing layering throughout the codebase
-- Adding `schemaMarkup: String?` to `PageContent` is additive and does not conflict with the Phase 5 component migration (which rewrites how content is built, not the protocol shape)
-- Schema types per section (auto-generated from existing metadata unless noted):
-  - Articles → `Article` (title, description, date, featuredImage — zero new front matter)
-  - Tutorials → `HowTo` (requires `howToSteps` front matter array, or extracted from `##` headings)
-  - Products → `SoftwareApplication` (platforms, technologies, appStoreURL, githubRepoName)
-  - FAQ pages → `FAQPage` (requires `faqItems` front matter array)
-  - Index / About-Us → `Organization` (hardcoded BrightDigit metadata)
-- The `.claude/ai-cite-optimization/` docs already define `FAQSchema`, `HowToSchema`, `ArticleSchema`, `Person`, `Organization`, `ImageObject` structures — wire these to the Swift build
-
-**Note:** FAQ and HowTo schemas are most valuable for AI citations. `Article` and `SoftwareApplication` schemas provide additional richness at zero content-authoring cost since all required fields already exist in `ItemMetadata`.
-
-### 3B: Validation
+Answer-first rewrites, question-style headings, comparison tables, and authoritative citations on the priority "money articles." Moved into Phase 3 from the former "Post-Migration: Content & Articles" milestone (the schema dependency gate is gone, so these are immediately actionable).
 
 | # | Title | Priority | Status |
 |---|-------|----------|--------|
-| [#23](https://github.com/brightdigit/brightdigit.com/issues/23) | Test AI-CITE Baseline and Validate Schema | P1-high | Open |
+| [#21](https://github.com/brightdigit/brightdigit.com/issues/21) | Optimize Mise Setup Guide for AI-CITE | P1-high | Open |
+| [#22](https://github.com/brightdigit/brightdigit.com/issues/22) | Optimize Best Backend Article for AI-CITE | P1-high | Open |
+| [#26](https://github.com/brightdigit/brightdigit.com/issues/26) | Optimize iOS CI/CD Article for AI-CITE | P1-high | Open |
+| [#27](https://github.com/brightdigit/brightdigit.com/issues/27) | Optimize iOS Architecture Article for AI-CITE | P1-high | Open |
+| [#28](https://github.com/brightdigit/brightdigit.com/issues/28) | Optimize Remaining Priority Articles (Batch) | P1-high | Open |
+| [#130](https://github.com/brightdigit/brightdigit.com/issues/130) | Split `dependency-management-swift` into two answer-first pages | P1-high | Open |
 
-**Reference:** `.claude/ai-cite-optimization/`
+### 3B: Site-level tasks
+
+| # | Title | Priority | Status |
+|---|-------|----------|--------|
+| [#129](https://github.com/brightdigit/brightdigit.com/issues/129) | Fix misleading freshness signal: real publish/`dateModified` dates sitewide | P0-critical | Open |
+| [#131](https://github.com/brightdigit/brightdigit.com/issues/131) | Add `robots.txt` with a `Sitemap:` line | P2-medium | Open |
+| [#132](https://github.com/brightdigit/brightdigit.com/issues/132) | Normalize brand name ("BrightDigit") sitewide | P2-medium | Open |
+
+**#129 is the one surviving `PiHTMLFactory` code task:** the footer at `Sources/BrightDigitSite/Nodes/Node+HTML.swift:187-191` renders `.year()` (current build year) as a false freshness signal; replace it and surface real per-page dates (`item.metadata.date` already exists across `Nodes/Section/*`). Crawlability is otherwise good (server-rendered, `index,follow` meta emitted, valid sitemap); #131 just adds the `Sitemap:` pointer.
+
+### 3C: Measurement
+
+| # | Title | Priority | Status |
+|---|-------|----------|--------|
+| [#23](https://github.com/brightdigit/brightdigit.com/issues/23) | Establish AI-citation baseline test | P1-high | Open |
+
+Run the 10-query baseline (ChatGPT/Claude/Perplexity + Google AI Overview) **before** the content work lands, then re-test weekly. No schema validation.
+
+**Reference:** `brightdigit/llm-ready-web` `main` — `resources/geo-evidence-review.md`, `resources/ai-cite-framework.md`, `case-studies/brightdigit-ai-cite/`.
 
 ---
 
@@ -202,7 +197,7 @@ Phase 8 (Final cleanup) ─────────────── anytime, l
 
 **Plot API context:** Plot has two coexisting APIs. The **Node API** (`Node<HTML.BodyContext>`) is lower-level and functional — used throughout `Nodes/`. The **Component API** (`Component` protocol, SwiftUI-style `var body: Component`) is declarative and already used in `Components/` (SectionElement, ServiceBox, Icon, ListItem) and in `ServicesBuilder.swift` and `ProductItem.swift`. Nodes conform to `Component`; components bridge back via `.convertToNode()`.
 
-**Migration approach:** Keep `PageContent.main` as `[Node<HTML.BodyContext>]`; leaf components call `.convertToNode()` at the boundary. This matches the pattern already established in `ProductItem.swift` and avoids a `PageContent` protocol break. The `schemaMarkup: String?` property added to `PageContent` in Phase 3 carries forward unchanged.
+**Migration approach:** Keep `PageContent.main` as `[Node<HTML.BodyContext>]`; leaf components call `.convertToNode()` at the boundary. This matches the pattern already established in `ProductItem.swift` and avoids a `PageContent` protocol break. (The `schemaMarkup: String?` property once planned for Phase 3 is no longer being added — the schema work was retired in the 2026-07 evidence reframe — so there is nothing extra to carry through this migration.)
 
 **Migration order:** (1) header/footer in `PiHTMLFactory.HTML.swift` (affects every page), (2) `Nodes/Section/` item content files, (3) `Nodes/Pages/` builders.
 
@@ -316,7 +311,7 @@ New source modules (local to this repo, not subrepos):
 
 ## Post-Migration Content Tasks
 
-**Goal:** Pure content edits and article optimization — no code changes required. Deferred until the schema pipeline (Phase 3A + Swift migration) is stable.
+**Goal:** Pure content edits — no code changes required. (The AI-CITE **article optimization** issues formerly listed here — #21/#22/#26/#27/#28 — moved into **Phase 3** as part of the 2026-07 evidence reframe; see Phase 3 §3A.)
 
 **Note:** Apply the `article-edit` GitHub label to all issues below to distinguish from migration/code issues.
 
@@ -327,18 +322,6 @@ New source modules (local to this repo, not subrepos):
 | [#3](https://github.com/brightdigit/brightdigit.com/issues/3) | Add Additional Local Storage Options | Open |
 | [#4](https://github.com/brightdigit/brightdigit.com/issues/4) | Add Main Actor to Swift 6 Article Solution | Open |
 | [#13](https://github.com/brightdigit/brightdigit.com/issues/13) | Clarify String vs Reference design choice in MistKit article | Open |
-
-### Article Optimization (formerly Phase 1B)
-
-| # | Title | Priority | Status |
-|---|-------|----------|--------|
-| [#21](https://github.com/brightdigit/brightdigit.com/issues/21) | Optimize Mise Setup Guide for AI-CITE | P1-high | Open |
-| [#22](https://github.com/brightdigit/brightdigit.com/issues/22) | Optimize Best Backend Article for AI-CITE | P1-high | Open |
-| [#26](https://github.com/brightdigit/brightdigit.com/issues/26) | Optimize iOS CI/CD Article for AI-CITE | P1-high | Open |
-| [#27](https://github.com/brightdigit/brightdigit.com/issues/27) | Optimize iOS Architecture Article for AI-CITE | P1-high | Open |
-| [#28](https://github.com/brightdigit/brightdigit.com/issues/28) | Optimize Remaining Priority Articles (Batch) | P1-high | Open |
-
-**Dependency:** Phase 3A ([#19](https://github.com/brightdigit/brightdigit.com/issues/19) schema implementation) must be complete and stable before article optimization begins.
 
 ---
 
@@ -357,11 +340,11 @@ New source modules (local to this repo, not subrepos):
 | Phase 0 | 2 | Quick wins |
 | Phase 1 | 0 | Monorepo cleanup ([#36](https://github.com/brightdigit/brightdigit.com/issues/36) already done; MarkdownGenerator removal folded into Phase 4 [#40](https://github.com/brightdigit/brightdigit.com/issues/40); [#47](https://github.com/brightdigit/brightdigit.com/issues/47) retitled and moved to Phase 4) |
 | Phase 2 | 4 | Swift 6.3 main package + lint config ([#54](https://github.com/brightdigit/brightdigit.com/issues/54)) + CI cache ([#65](https://github.com/brightdigit/brightdigit.com/issues/65)) + rebuild-avoidance (TBD) |
-| Phase 3 | 5 | AI-CITE schema ([#56](https://github.com/brightdigit/brightdigit.com/issues/56), [#18](https://github.com/brightdigit/brightdigit.com/issues/18), [#19](https://github.com/brightdigit/brightdigit.com/issues/19), [#20](https://github.com/brightdigit/brightdigit.com/issues/20)) + validation ([#23](https://github.com/brightdigit/brightdigit.com/issues/23)) |
+| Phase 3 | 10 | AI-CITE content optimization (evidence reframe): articles [#21](https://github.com/brightdigit/brightdigit.com/issues/21)/[#22](https://github.com/brightdigit/brightdigit.com/issues/22)/[#26](https://github.com/brightdigit/brightdigit.com/issues/26)/[#27](https://github.com/brightdigit/brightdigit.com/issues/27)/[#28](https://github.com/brightdigit/brightdigit.com/issues/28) + split [#130](https://github.com/brightdigit/brightdigit.com/issues/130); site-level dates [#129](https://github.com/brightdigit/brightdigit.com/issues/129)/robots [#131](https://github.com/brightdigit/brightdigit.com/issues/131)/brand [#132](https://github.com/brightdigit/brightdigit.com/issues/132); baseline [#23](https://github.com/brightdigit/brightdigit.com/issues/23). Schema issues #19/#20/#56/#18 **closed as wontfix** |
 | Phase 4 | 7 | OpenAPI migration + Kanna → SwiftSoup ([#47](https://github.com/brightdigit/brightdigit.com/issues/47)) |
 | Phase 5 | 5 | Swift 6.3 subrepos + components + Tailwind (TBD) + AI-CITE content strategy ([#24](https://github.com/brightdigit/brightdigit.com/issues/24), [#25](https://github.com/brightdigit/brightdigit.com/issues/25)) |
 | Phase 6 | 5 | Publishing infrastructure + AT Protocol ([#49](https://github.com/brightdigit/brightdigit.com/issues/49)) feeds Buffer |
 | Phase 7 | 2 | Platform migration + form integration (TBD) |
 | Phase 8 | 3 | Deferred cleanup |
-| Post-Migration | 8 | Article edits ([#3](https://github.com/brightdigit/brightdigit.com/issues/3), [#4](https://github.com/brightdigit/brightdigit.com/issues/4), [#13](https://github.com/brightdigit/brightdigit.com/issues/13)) + article optimization ([#21](https://github.com/brightdigit/brightdigit.com/issues/21), [#22](https://github.com/brightdigit/brightdigit.com/issues/22), [#26](https://github.com/brightdigit/brightdigit.com/issues/26), [#27](https://github.com/brightdigit/brightdigit.com/issues/27), [#28](https://github.com/brightdigit/brightdigit.com/issues/28)) |
-| **Total** | **41** | Excludes [#12](https://github.com/brightdigit/brightdigit.com/issues/12) (done), [#36](https://github.com/brightdigit/brightdigit.com/issues/36) (done), [#43](https://github.com/brightdigit/brightdigit.com/issues/43) (dropped); includes 3 TBD issues awaiting GitHub creation (Phase 2 rebuild-avoidance, Phase 5 Tailwind, Phase 7 form integration) |
+| Post-Migration | 3 | Article edits ([#3](https://github.com/brightdigit/brightdigit.com/issues/3), [#4](https://github.com/brightdigit/brightdigit.com/issues/4), [#13](https://github.com/brightdigit/brightdigit.com/issues/13)); article-optimization issues moved to Phase 3 |
+| **Total** | **41** | Excludes [#12](https://github.com/brightdigit/brightdigit.com/issues/12) (done), [#36](https://github.com/brightdigit/brightdigit.com/issues/36) (done), [#43](https://github.com/brightdigit/brightdigit.com/issues/43) (dropped), and the 4 schema issues [#19](https://github.com/brightdigit/brightdigit.com/issues/19)/[#20](https://github.com/brightdigit/brightdigit.com/issues/20)/[#56](https://github.com/brightdigit/brightdigit.com/issues/56)/[#18](https://github.com/brightdigit/brightdigit.com/issues/18) (closed wontfix, 2026-07); Phase 3 gained 4 new issues ([#129](https://github.com/brightdigit/brightdigit.com/issues/129)–[#132](https://github.com/brightdigit/brightdigit.com/issues/132)) — net unchanged. Includes 3 TBD issues awaiting GitHub creation (Phase 2 rebuild-avoidance, Phase 5 Tailwind, Phase 7 form integration) |

--- a/docs/content-ops-plan.md
+++ b/docs/content-ops-plan.md
@@ -27,7 +27,9 @@ refactor will separate `Content/*.md` from `Sources/*.swift` — the front-matte
 contract is unchanged by that split.
 
 **Goal:** define the GitHub issues (in `brightdigit.com`) that build a content-planning /
-scaffolding infrastructure, aligned to the existing migration phases.
+scaffolding infrastructure, aligned to the existing migration phases. See
+[How it works end-to-end](#how-it-works-end-to-end) for a concrete walkthrough of the whole system in
+motion before the issue catalog.
 
 ## Design decisions
 
@@ -48,6 +50,144 @@ scaffolding infrastructure, aligned to the existing migration phases.
 6. **Topic entity is private-only for now:** the topic/campaign record is a first-class entity, but
    its records live **only in year-in-review**. brightdigit.com published items carry only the
    cross-media **link fields**; the public site never hosts topic records.
+
+## How it works end-to-end
+
+The issue set above (I1–I6) is a parts list. This section shows the machine running: how the repos
+are arranged, and one concrete topic traveling from a mining hit to published-and-fanned-out content
+across media. It describes the **target** arrangement — the Swift-package split and the Phase-6
+fan-out are planned, not yet shipped; the language below flags what is future work.
+
+### The repo arrangement
+
+The plan splits along **two axes at once**: private-vs-public *and* content-vs-Swift-code. Today
+`brightdigit.com` is a single repo mixing `Content/*.md` with `Sources/*.swift`. The target pulls the
+Swift packages out into their own repo(s), leaving the content + site repo depending on them — three
+homes joined by two seams.
+
+- **`leogdion/year-in-review` (private) — the planning hub.** Holds the topic/campaign **records** (I3
+  shape), the `/content-topic-mining` skill, the three pillars (AI+Swift, Opinion/Reflection, OSS
+  Releases), the per-platform voice guides (`social-posts/README.md`, `newsletters/README.md`,
+  `planning/content-strategy-2026.md`), and per-medium **draft** copy. This is where a human plus
+  Claude Code plan and write.
+
+- **`brightdigit.com` (public) — the content + site repo.** After the split it keeps `Content/*.md`
+  plus site config in place and **depends on** the extracted Swift package repo(s). It holds the
+  published items — front matter carrying only the cross-media **link fields** (I1), never topic
+  records — and the **derived companion spec** (I2 output, pulled from the package repo). It runs the
+  Publish pipeline that renders, publishes, and fans out. It no longer *owns* the metadata types.
+
+- **Extracted Swift package repo(s) — the contract + the engine.** `BrightDigitSite`, `PublishType`,
+  and the Phase-6 modules (`PublishKit` / `ButtondownKit` / `BufferKit` / `ATProtoKit`) move here as
+  standalone Swift packages. **The authoritative front-matter↔Swift-struct contract (`ItemMetadata` /
+  `PublishType`) travels with them** — so the schema lives in the package repo and the content repo
+  consumes it as a versioned dependency. This is the single source of truth I2 reads from.
+
+**Two seams keep everything in sync:**
+
+- **The contract seam (package repo → everywhere).** I2's "pull latest Swift type → emit current spec"
+  now means *pull from the package repo* — a clean versioned dependency boundary, not reaching into a
+  subfolder. The generated spec flows into both the content repo (validation at publish time) and
+  `year-in-review` (so drafts are authored against the current fields). Splitting the packages out
+  actually *strengthens* I2: the source of truth is a released package, not a path.
+- **The content seam (year-in-review → brightdigit.com).** Only **finished items plus their I1 link
+  fields** land in `Content/`. Topic records, briefs, and voice guides stay private.
+
+The **`/content-plan` skill (I5) is portable** — the *same* skill package runs in both the private and
+public repos, which is what lets both seams stay clean: identical rules on both sides. And because the
+contract is optional Codable fields on a struct, the repo split changes *which repo owns
+`ItemMetadata`*, not the field vocabulary — I1's fields travel with the packages unchanged (the same
+[Refactor-proof](#alignment-notes) logic, extended from a `Content/`↔`Sources/` folder split to a full
+repo split).
+
+### The walkthrough: mining hit → money article → newsletter → social
+
+One topic, eight beats. **Beats 1–4 are private planning, beat 5 is the boundary crossing, beats 6–8
+are the public pipeline.** Throughout, the system **guides and scaffolds — it never ghost-writes the
+long-form copy**; that stays a human/`prose-editor` step (beat 4).
+
+1. **Mining hit** *(year-in-review · Claude Code · existing `/content-topic-mining`)*. Mining surfaces
+   a candidate: *"developers keep asking how to wire up mise for a Swift CI toolchain."*
+
+2. **Topic record created** *(year-in-review · `/content-plan`, I5 → I3)*. The skill turns the hit into
+   a canonical **topic entity**: slug `mise-swift-ci`, source (the mining hit / a related PR), pillar
+   `AI+Swift`, status, and a **fan-out map** — the media/platforms this topic will spawn (article →
+   newsletter → X/LinkedIn/Mastodon). No drafts yet. The record lives only here.
+
+3. **Briefs generated** *(year-in-review · `/content-plan`, I4 + I2 spec)*. The skill emits per-medium
+   **briefs** — the article brief (hook, angle, AI-CITE key points, CTA, links), the newsletter brief,
+   the social variants. **Scaffolds, not copy.** Their link fields are validated against the
+   **I2-derived spec** so they will conform to what the Swift renderer expects.
+
+4. **Article drafted + AI-CITE optimized** *(year-in-review · human/Claude Code + `prose-editor`)*. The
+   "money article" is written from the brief, applying the Phase-3 AI-CITE levers — **A**nswer-first,
+   **I**ntent-matched (question) headings, **C**lear structure, **T**rusted sources (citations),
+   **E**xclusive POV. The `prose-editor` agent reviews. The long-form copy lives privately until ready.
+
+5. **Item crosses into `brightdigit.com` with link fields** *(the boundary · I1)*. The finished article
+   moves to `Content/articles/…md`, and its front matter now carries the **proposed I1 cross-media link
+   fields** — additive, optional, Codable, decoded by `ItemMetadata`:
+
+   ```yaml
+   # today — bare front matter (Content/articles/2020-apple-watch.md)
+   title: Why 2020 will be amazing for the Apple Watch
+   date: 2020-04-13 06:30
+   description: …
+   tags: Apple Hardware, Apple Watch, apple-development, swiftui
+   featuredImage: /media/…/daniel-canibano-….jpg
+   ```
+
+   ```yaml
+   # with the proposed I1 fields (additive — nothing above changes)
+   title: Wiring up mise for a Swift CI toolchain
+   date: 2026-08-01 06:30
+   description: …
+   featuredImage: /media/…/mise-swift-ci.jpg
+   topicSlug: mise-swift-ci                              # I1 (proposed)
+   sourceRef: year-in-review#mise-swift-ci              # I1 (proposed)
+   related:                                              # I1 (proposed)
+     newsletter: /newsletters/2026-08-mise-swift-ci/
+     social: https://bsky.app/profile/…/post/…
+   ```
+
+   Additive safety is already proven in this repo: content files carry YAML keys `ItemMetadata` does
+   not model (`campaignID`, `newsletterTitle`, `tags`) and Publish decodes them without failure — the
+   same rationale the PRD gave the (retired) `schemaMarkup` field.
+
+6. **Staged as a draft via future-dating** *(brightdigit.com)*. Because **"draft" = future-dated
+   only**, the item ships with a future `date:` — visible in `--mode drafts` builds, stripped from
+   production by the `item.date > now` filter (`Sources/BrightDigitSite/BrightDigitSite.swift:196`) —
+   until launch day. No `draft:` flag is needed; this is the existing mechanism I6 leans on.
+
+7. **Published** *(brightdigit.com · Swift pipeline)*. On or after the date, `--mode production` renders
+   the article; the renderer reads the I1 fields; the item goes live at `brightdigit.com/articles/…`.
+
+8. **Fan-out** *(brightdigit.com · I6, Phase 6 — later)*. The topic's fan-out map plus the item's I1
+   link fields drive the outbound leg: newsletter via `ButtondownKit`, social via `BufferKit` /
+   `ATProtoKit` (a canonical `app.bsky.feed.post` record → a single GraphQL mutation → all networks).
+   The published article is the hub the newsletter and posts link back to. This beat **depends on
+   #33/#31/#30/#49** and the Phase-6 modules existing.
+
+### Which issue powers which beat
+
+| Beat | Issue | Repo | New capability |
+|---|---|---|---|
+| 2 topic record | I3 | year-in-review | canonical topic entity (records private) |
+| 3 briefs | I4 (+ I2 spec) | year-in-review | per-medium scaffolds, spec-validated |
+| 2–5 orchestration | I5 | both (portable) | `/content-plan` skill |
+| 5 link fields | I1 | package repo (fields) → brightdigit.com (values) | additive `ItemMetadata` fields |
+| 3 / 5 spec | I2 | package repo → content repo + year-in-review | Swift-type → spec generator (pull latest package) |
+| 8 fan-out | I6 | brightdigit.com + package repo | publish + Buttondown/Buffer/AT wiring |
+
+### Why this arrangement
+
+Records stay private because a content strategy and backlog is not something to publish. The **Swift
+package repo owns the contract** because the Swift program is what actually renders HTML and fans out —
+the fields it needs are the fields that matter — while the content repo depends on that package and
+carries only link-field *values*. The portable `/content-plan` skill and the package-derived spec are
+the two seams that keep private planning and public publishing in sync without duplicating the
+vocabulary. The repo split makes that contract a **versioned dependency rather than a folder**, which
+is exactly what lets the spec generator (I2) stay honest.
 
 ## Proposed issues
 

--- a/docs/content-ops-plan.md
+++ b/docs/content-ops-plan.md
@@ -1,0 +1,127 @@
+# Content-Planning Infrastructure — Proposed Issue Set
+
+**Status:** Draft for review · **Target repo:** `brightdigit/brightdigit.com` · **2026-07**
+
+## Context
+
+`leogdion/year-in-review` (private) is the planning/draft hub for all BrightDigit/EmpowerApps
+content — articles, podcast episodes, newsletters, multi-platform social posts, and talks. It
+already has a mature-but-ad-hoc system: content organized by medium, YAML front matter with a
+hand-authored `related:` graph, a `/content-topic-mining` skill, per-platform voice guides, and
+three content pillars (AI+Swift, Opinion/Reflection, OSS Releases). It already links to **live
+brightdigit.com URLs** (e.g. a social clip's `related.episode:
+https://brightdigit.com/episodes/209-…/`), and newsletters are Buttondown-markdown-native.
+
+**The gap:** there is no *defined, executable infrastructure* that lets Claude Code **guide** future
+content across every medium/platform **without writing full drafts**. Today the cross-media fan-out
+is inferred from matching filenames + a drifting `related:` vocabulary; there is no canonical
+"topic" record; status tracking is duplicated and manual; and none of it is connected to the Swift
+program that actually renders and publishes the public site.
+
+The public site (`brightdigit.com`) is a Swift Publish static-site generator: five sections
+(`articles`/`episodes`/`tutorials`/`newsletters`/`products`), one `Codable` metadata struct
+(`BrightDigitSite.ItemMetadata`) that the pipeline decodes from front matter and that the renderer
+plus the future fan-out consume. "Draft" today = future-dated only (no `draft:` flag). Phase 6 will
+add `PublishKit`/`ButtondownKit`/`BufferKit`/`ATProtoKit` for newsletter + social fan-out. A future
+refactor will separate `Content/*.md` from `Sources/*.swift` — the front-matter↔Swift-struct
+contract is unchanged by that split.
+
+**Goal:** define the GitHub issues (in `brightdigit.com`) that build a content-planning /
+scaffolding infrastructure, aligned to the existing migration phases.
+
+## Design decisions
+
+1. **Deliverables (all four):** canonical topic entity · per-medium/platform briefs · unified
+   cross-media link schema · a `/content-plan` skill.
+2. **Coupling:** build the **planning layer now**; wire publish/fan-out **later** (do not block on
+   unbuilt Phase 6 modules).
+3. **Phase fit — split:** schema + spec-generator + briefs + skill → **Phase 3 (content)**;
+   publish/fan-out wiring → **Phase 6 (publishing infra)**.
+4. **Schema is Swift-first, spec is derived.** The authoritative contract is the Swift metadata
+   types (`PublishType` / `ItemMetadata`) — the fields the renderer and fan-out require, because the
+   Swift program is what renders HTML and publishes/fans out. **No hand-maintained spec doc.**
+   Instead a generator (a skill, or a `/content-plan` sub-step) **parses the latest Swift type and
+   emits the companion spec on the fly** — an easy "pull latest Swift file → produce current spec"
+   path. The private repo and the skill consume that generated spec.
+5. **Skill is portable:** a self-contained `/content-plan` skill package (+ voice/pillar/platform
+   guides) usable from **both** repos.
+6. **Topic entity is private-only for now:** the topic/campaign record is a first-class entity, but
+   its records live **only in year-in-review**. brightdigit.com published items carry only the
+   cross-media **link fields**; the public site never hosts topic records.
+
+## Proposed issues
+
+Ordering: **I1** (link-field schema) is foundational — the generator (I2), briefs (I4), and skill
+(I5) all consume it. **I6** (fan-out) is Phase 6 and depends on the Phase 3 pieces landing.
+
+### Phase 3 — planning layer (schema, spec, briefs, skill)
+
+#### I1 — Cross-media link schema on published items (Swift types) · P1-high
+Extend `BrightDigitSite.ItemMetadata` (`Sources/BrightDigitSite/BrightDigitSite.swift`) and the
+`PublishType` protocol layer (`Sources/PublishType/`) with a **unified, validated cross-media link
+vocabulary**, replacing the drifting free-text `related.social` / `related.newsletter` /
+`related.episode`. Fields let a published site item declare its topic slug and cross-media siblings
+(e.g. `topicSlug`, `sourceRef`, `related.{episode,newsletter,social,article,talk,video}`). Codable,
+optional, additive (does not break existing content). This is the **contract** the renderer and the
+future fan-out read.
+*Coordinate with the Phase-5 component migration — additive fields on `ItemMetadata` don't conflict
+(same rationale the PRD uses for `schemaMarkup`).*
+Labels: `enhancement`.
+
+#### I2 — Swift-type → companion-spec generator · P1-high · depends on I1
+A capability (standalone skill, or a sub-step invoked by `/content-plan`) that **reads the latest
+`ItemMetadata` / `PublishType` Swift source and emits a current, human/machine-readable companion
+spec** (fields, types, link vocabulary). No hand-maintained schema doc — always derived from the
+authoritative Swift types via an easy "pull latest → generate spec" path. Output is what the private
+repo drafts and the briefs/skill validate against.
+Labels: `enhancement`, `documentation`.
+
+#### I3 — Canonical topic-entity definition (private-only records) · P2-medium · relates to I1
+Define the topic/campaign entity: id/slug, source (repo/PR/episode/release), status, and the fan-out
+map (which media + platforms it spawns). Specify it as a **type/shape** so records are consistent,
+but its **records live only in year-in-review** — brightdigit.com hosts the *definition* + the link
+fields (I1), not topic records. Documents how a topic threads mining → briefs → per-platform drafts
+→ published items.
+Labels: `documentation`, `enhancement`.
+
+#### I4 — Per-medium/platform content briefs (scaffolds, not drafts) · P1-high · depends on I1, I2
+Templates/scaffolds per medium+platform (article, tutorial, episode clip, newsletter, and
+Twitter/LinkedIn/Mastodon/YouTube/Patreon variants): hook, angle, key points, CTA, length, voice,
+links — **structured guidance, not full copy**. Encodes the voice/pillar/platform guides distilled
+from year-in-review (`social-posts/README.md`, `newsletters/README.md`,
+`planning/content-strategy-2026.md`). Conforms to the I1 fields / I2 spec.
+Labels: `documentation`.
+
+#### I5 — Portable `/content-plan` skill · P1-high · depends on I1, I2, I4
+A self-contained skill package usable from both repos. Input: a source (mining hit / episode /
+release / PR). Output: a topic record (I3 shape) + per-medium/platform briefs (I4), enforcing the
+pillars and voice/platform guides and emitting front matter conformant to the I1 fields (validated
+via the I2-generated spec). Complements the existing `/content-topic-mining` skill (mining → this →
+briefs). **Writes guidance, never final long-form copy.**
+Labels: `enhancement`.
+
+### Phase 6 — publish / fan-out wiring (later)
+
+#### I6 — Wire the content plan to the publish + fan-out pipeline · P1-high · depends on I1–I5, #33/#31/#30/#49
+Consume the I1 link fields / topic plan to drive fan-out once Phase 6 modules exist: newsletter via
+`ButtondownKit`, social via `BufferKit`/`ATProtoKit`, site items via the Publish pipeline + the
+future-date "draft" mechanism. Turns a planned topic into scheduled/published outputs across media.
+Labels: `enhancement`.
+
+## Alignment notes
+
+- **Phase 3** currently holds the evidence-backed content-optimization work (PR #133 reframe:
+  articles + site tasks + baseline). The planning-infra issues (I1–I5) fit its "content" theme.
+- **Phase 6** holds the publishing architecture (`#33` umbrella, `#31` newsletters, `#30` Buffer,
+  `#49` AT). I6 slots there and depends on them.
+- House style: dependency links as `Depends on:` / `Related:` body lines; reuse existing labels
+  (`enhancement`, `documentation`, `P0/P1/P2-*`); milestone via `-m`.
+- **Refactor-proof:** the schema is front-matter fields on a Codable Swift struct — the future
+  `Content/` ↔ `Sources/` split changes *where files live*, not the field contract, so I1's fields
+  travel with the content unchanged.
+
+## Open sequencing question
+
+Whether to group I1–I5 under a **new "Content Ops" milestone** vs. folding into Phase 3 was raised;
+current choice is the **split (Phase 3 + Phase 6)**. If Phase 3 gets crowded, revisit a dedicated
+milestone at execution time.


### PR DESCRIPTION
## Summary

Consolidates two roadmap/docs PRs into one. Combines the branches of **#133** and **#128** (both now merged into this branch), and adds a content-planning infrastructure proposal.

## 1. Content-planning infrastructure proposal (new docs)

`docs/content-ops-plan.md` — draft proposal for the content-ops issue set (I1–I6), for review before turning into GitHub issues (split across Phase 3 planning layer and Phase 6 fan-out):

- Cross-media link schema on `ItemMetadata`
- Swift-type → companion-spec generator
- Canonical topic entity (private-only records)
- Per-medium / per-platform briefs
- A portable `/content-plan` skill
- Phase 6 publish / fan-out wiring

## 2. Reframe Phase 3 (AI-CITE) around evidence-backed levers — was #133

Re-aligns **Phase 3: AI-CITE Optimization** to the updated GEO evidence in [`brightdigit/llm-ready-web`](https://github.com/brightdigit/llm-ready-web). Schema/JSON-LD is not a proven AI-citation lever and `llms.txt` has null effect, so the framework dropped its "Indexed Schema" element (now 5: **A**nswer-first, **I**ntent-matched headings, **C**lear structure, **T**rusted sources, **E**xclusive POV).

- Phase 3 rewritten: 5-element framework; schema subsection removed; new §3A content optimization / §3B site-level / §3C measurement tables; proven-lever ranking.
- Removed the "Phase 3A schema must complete before article optimization" dependency gate.
- Dependency-chain graph + issue-count summary updated; stale Phase 5 `schemaMarkup` carry-forward note corrected.

Issue surgery already live: closed #19/#20/#56/#18 as `wontfix`; reframed #23; moved #21/#22/#26/#27/#28 into Phase 3; created #129/#130/#131/#132.

## 3. Pull Buttondown newsletter/email work forward into Phase 5 — was #128

Reprioritizes the high-priority Buttondown newsletter/email work by pulling it from Phase 6 into **Phase 5**. Phase 5 and 6 are siblings (both require only Phase 4), so the chain was never gated behind the Swift 6.3 / component migration.

- `PRD.md`: Phase 5 table gains the 4 pulled-forward issues (#124, #122, #127, #126); Phase 6 gains a "moved to Phase 5" note; dependency-chain note added.

## Provenance

Replaces #133 and #128, both merged into this branch (two merge commits over `main`). Files changed: `PRD.md`, `docs/content-ops-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the project roadmap with revised phase sequencing, clearer milestone tracking, and adjusted issue assignments/counts (including schema items marked wontfix).
  * Reframed the Phase 3 plan into an evidence-backed “AI-CITE” framework (answer-first, intent-matched structure, trusted sources, exclusive POV) with measurement guidance; removed the prior schema-implementation milestone.
  * Added a new end-to-end content-planning workflow document, including link/schema, brief scaffolding, and publishing/fan-out coordination beats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->