### PR TITLE
Fix "Donny Wall" misspelling to "Donny Wals" (episode 210)

### DIFF
--- a/Content/_redirects
+++ b/Content/_redirects
@@ -136,3 +136,4 @@
 /blog/2021/02/25/working-remotely-ios-development	/articles/working-remotely-ios-development
 /blog/2021/03/26/upgrading-old-ios-apps	/articles/upgrading-old-ios-apps
 /blog/2021/05/04/4-tips-apple-store-review-guidelines	/articles/4-tips-apple-store-review-guidelines
+/episodes/210-practical-agents-with-donny-wall/	/episodes/210-practical-agents-with-donny-wals/

--- a/Content/episodes/210-practical-agents-with-donny-wals.md
+++ b/Content/episodes/210-practical-agents-with-donny-wals.md
@@ -1,5 +1,5 @@
 ---
-title: Practical Agents with Donny Wall
+title: Practical Agents with Donny Wals
 date: 2026-07-12 16:12
 description: 'Donny Wals returns to talk through a year of agentic coding. We go through how it has changed his architecture decisions, reviewing PRs he didn''t write himself, managing tasks and context across parallel agents, and the gym-workout crash he fixed from his phone mid-set — plus where he still doesn''t trust the agent: SwiftData migrations.'
 featuredImage: https://img.transistorcdn.com/_ztiwhi4w6vHV-jhbuUfPSkP3BVJckGJZykpFC7L3mk/rs:fill:0:0:1/w:1400/h:1400/q:60/mb:500000/aHR0cHM6Ly9pbWct/dXBsb2FkLXByb2R1/Y3Rpb24udHJhbnNp/c3Rvci5mbS9mOTlj/ZjE1MmFjY2NlMzky/MThiNjAyZDgzNGMy/YjIwNy5qcGc.jpg


### PR DESCRIPTION
## Summary

Episode 210 was published with the guest's last name misspelled as **"Wall"** instead of **"Wals"**. This fixes it in the two places that matter:

- **Title front-matter** — `title: Practical Agents with Donny Wals`
- **Filename** (drives the URL slug) — renamed `210-practical-agents-with-donny-wall.md` → `210-practical-agents-with-donny-wals.md` via `git mv` (history preserved)

The file body already used "Donny Wals" correctly everywhere else.

## Redirect

Since the episode was already published (2026-07-12), the old wrong URL may have been shared/indexed, so a redirect was added to `Content/_redirects`:

```
/episodes/210-practical-agents-with-donny-wall/	/episodes/210-practical-agents-with-donny-wals/
```

This is the first `/episodes/…` entry in `_redirects`, but the tab-separated old→new format matches the existing entries.

## Verification

- `ls Content/episodes/ | grep 210` shows only the corrected `…-donny-wals.md`
- `grep "Wall" …-donny-wals.md` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the episode title to display “Donny Wals.”
  * Added a redirect so the previous episode URL continues to work.
  * Preserved the existing blog article redirect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->