### PR TITLE
#146 Spinetail read-path: page sentCampaigns + verify archiveHTML for #127

### DIFF
--- a/Packages/BrightDigit/Spinetail/Sources/Spinetail/MailchimpClient.swift
+++ b/Packages/BrightDigit/Spinetail/Sources/Spinetail/MailchimpClient.swift
@@ -107,29 +107,52 @@ public struct MailchimpClient: Sendable {
 
   /// Lists the sent campaigns for a list, most recent first.
   ///
+  /// Pages through the full result set: Mailchimp caps `count` at
+  /// ``maxCount`` per request, so this issues successive `getCampaigns` calls
+  /// with an advancing `offset` until every campaign the server reports
+  /// (`total_items`) has been collected. This matters for the archive backfill,
+  /// which must not silently drop the oldest issues if the account ever exceeds
+  /// one page of sent campaigns.
+  ///
   /// - Parameter listID: The Mailchimp list (audience) id to filter by.
-  /// - Returns: The sent campaigns mapped into the flat importer model.
+  /// - Returns: The sent campaigns mapped into the flat importer model, most
+  ///   recent first.
   /// - Throws: ``ClientError/invalidResponse`` for a non-200 response.
   public func sentCampaigns(
     forListID listID: String
   ) async throws -> [MailchimpCampaign] {
-    let response = try await underlying.getCampaigns(
-      .init(
-        query: .init(
-          count: Self.maxCount,
-          status: .sent,
-          list_id: listID,
-          sort_field: .send_time,
-          sort_dir: .DESC
+    var collected: [MailchimpCampaign] = []
+    var offset = 0
+    while true {
+      let response = try await underlying.getCampaigns(
+        .init(
+          query: .init(
+            count: Self.maxCount,
+            offset: offset,
+            status: .sent,
+            list_id: listID,
+            sort_field: .send_time,
+            sort_dir: .DESC
+          )
         )
       )
-    )
-    guard case .ok(let okResponse) = response,
-      case .json(let body) = okResponse.body
-    else {
-      throw ClientError.invalidResponse
+      guard case .ok(let okResponse) = response,
+        case .json(let body) = okResponse.body
+      else {
+        throw ClientError.invalidResponse
+      }
+      let page = body.campaigns ?? []
+      collected.append(contentsOf: page.map(MailchimpCampaign.init(from:)))
+      // Stop when the server reports no more items to fetch, or when a page
+      // comes back empty (defensive: guarantees termination even if
+      // `total_items` is absent or inconsistent).
+      let total = body.total_items ?? collected.count
+      if page.isEmpty || collected.count >= total {
+        break
+      }
+      offset += page.count
     }
-    return (body.campaigns ?? []).map(MailchimpCampaign.init(from:))
+    return collected
   }
 
   /// Fetches the archive HTML for a campaign.

--- a/Packages/BrightDigit/Spinetail/Tests/SpinetailTests/Fixtures.swift
+++ b/Packages/BrightDigit/Spinetail/Tests/SpinetailTests/Fixtures.swift
@@ -17,6 +17,27 @@ internal enum Fixtures {
     "total_items":2}
     """
 
+  /// First page of a two-page `getCampaigns` result (`total_items` = 3).
+  internal static let campaignsPage1 = """
+    {"campaigns":[\
+    {"id":"camp1","long_archive_url":"https://archive/1",\
+    "send_time":"2020-03-03T00:00:00+00:00",\
+    "settings":{"subject_line":"BrightDigit Newsletter #3","title":"Issue Three"}},\
+    {"id":"camp2","long_archive_url":"https://archive/2",\
+    "send_time":"2020-02-02T00:00:00+00:00",\
+    "settings":{"subject_line":"BrightDigit Newsletter #2","title":"Issue Two"}}],\
+    "total_items":3}
+    """
+
+  /// Second (final) page of the two-page `getCampaigns` result.
+  internal static let campaignsPage2 = """
+    {"campaigns":[\
+    {"id":"camp3","long_archive_url":"https://archive/3",\
+    "send_time":"2020-01-01T00:00:00+00:00",\
+    "settings":{"subject_line":"BrightDigit Newsletter #1","title":"Issue One"}}],\
+    "total_items":3}
+    """
+
   /// A `getCampaignsIdContent` OK response carrying archive HTML.
   internal static let campaignContent = """
     {"archive_html":"<html><body>Hello</body></html>","html":"<p>Hello</p>"}

--- a/Packages/BrightDigit/Spinetail/Tests/SpinetailTests/MailchimpClientTests.swift
+++ b/Packages/BrightDigit/Spinetail/Tests/SpinetailTests/MailchimpClientTests.swift
@@ -59,6 +59,27 @@ import Testing
     #expect(transport.authorizationHeaders.first == expectedAuth)
   }
 
+  /// `sentCampaigns(forListID:)` pages until every campaign the server reports
+  /// (`total_items`) has been collected, preserving order across pages.
+  @Test internal func listCampaignsPagesThroughAllResults() async throws {
+    let transport = MockTransport(
+      responses: [
+        Self.campaignsPath: [Fixtures.campaignsPage1, Fixtures.campaignsPage2]
+      ]
+    )
+    let client = try makeClient(transport)
+
+    let campaigns = try await client.sentCampaigns(forListID: Self.listID)
+
+    #expect(campaigns.map(\.id) == ["camp1", "camp2", "camp3"])
+    // Two GETs to /campaigns: the first page, then the offset follow-up.
+    let campaignsRequests = transport.requestedPaths.filter {
+      $0.hasPrefix(Self.campaignsPath)
+    }
+    #expect(campaignsRequests.count == 2)
+    #expect(campaignsRequests.last?.contains("offset=2") == true)
+  }
+
   /// `archiveHTML(forCampaignID:)` returns the campaign's `archive_html`.
   @Test internal func archiveHTMLReturnsArchiveHTML() async throws {
     let transport = MockTransport(


### PR DESCRIPTION
Resolves #146.

Verify/finish the Spinetail (Mailchimp) **read path** that the Buttondown archive repair (#127) depends on.

## What changed
- `MailchimpClient.sentCampaigns(...)` now **pages by `offset` until `total_items` is collected** (previously a single `count=1000` page that silently dropped the oldest issues once an account exceeded one page — unacceptable for a completeness-critical backfill). Defensive empty-page break guarantees termination.
- Added a multi-page unit test + two fixtures exercising the paging loop.
- Error handling (`invalidResponse`, `missingHTML`) was already adequate; left as-is.
- Did **not** touch the deprecated `ContributeMailchimp` module.

## Verification (live Mailchimp account)
- `sentCampaigns` returns **248 sent campaigns**; full history reachable (oldest send 2019-01-05 = Newsletter #1, newest 2025-12-11).
- Fields sufficient for #127: `id` 248/248, `sendTime` (date) 248/248, `subjectLine` 248/248, `title` 243/248 (the 5 missing fall back to `subjectLine` in existing selection code). `issueNo` derives from `subjectLine` at the args layer.
- `archiveHTML` for a sampled campaign returned a valid 45,099-char HTML document — body HTML is available.
- No secrets committed; live-check harness lived outside the repo and was deleted.

## Build/test
`Build complete!` under Swift 6.4 strict concurrency; 7/7 tests pass.

## Notes
Gate before #127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)