### PR TITLE
Point subscribe forms at Buttondown (#126)

### DIFF
--- a/Sources/BrightDigitSite/Nodes/Node+HTML.swift
+++ b/Sources/BrightDigitSite/Nodes/Node+HTML.swift
@@ -172,9 +172,7 @@ extension Node where Context == HTML.BodyContext {
           .li(href: "https://www.empowerapps.show", flatIcon: "podcast"),
           .li(href: "http://youtube.com/c/BrightdigitLLC", flatIcon: "youtube"),
           .li(
-            href:
-              // swiftlint:disable:next line_length
-              "https://us12.campaign-archive.com/home/?u=cb3bba007ed171091f55c47f0&id=584d0d5c40",
+            href: Strings.Buttondown.archiveURL,
             flatIcon: "newsletter"
           ),
           .li(href: "/feed.rss", flatIcon: "rss")

--- a/Sources/BrightDigitSite/Nodes/Node+Head.swift
+++ b/Sources/BrightDigitSite/Nodes/Node+Head.swift
@@ -86,10 +86,7 @@ extension Node where Context == HTML.DocumentContext {
       ),
       .link(
         .rel(.alternate), .type("application/rss+xml"), .title("BrightDigit Newsletter"),
-        .href(
-          // swiftlint:disable:next line_length
-          "https://us12.campaign-archive.com/feed?u=cb3bba007ed171091f55c47f0&id=584d0d5c40"
-        )
+        .href(Strings.Buttondown.rssURL)
       ),
 
       .link(.rel(.icon), .href("/favicon.ico"), .sizes("any"), .type("image/svg+xml")),
@@ -122,7 +119,7 @@ extension Node where Context == HTML.DocumentContext {
       .script(
         .defer(),
         .data(named: "domain", value: "brightdigit.com"),
-        .src("https://plausible.io/js/script.js")
+        .src("https://plausible.io/js/script.tagged-events.js")
       )
     )
   }

--- a/Sources/BrightDigitSite/Nodes/Section/NewsletterItem+Content.swift
+++ b/Sources/BrightDigitSite/Nodes/Section/NewsletterItem+Content.swift
@@ -35,9 +35,8 @@ import PublishType
 extension NewsletterItem {
   internal var formNode: Node<HTML.BodyContext> {
     .form(
-      .attribute(named: "name", value: "subscribers"),
+      .action(Strings.Buttondown.subscribeURL),
       .method(.post),
-      .attribute(named: "data-netlify", value: "true"),
       .div(
         .div(
           .input(
@@ -50,7 +49,16 @@ extension NewsletterItem {
       ),
       .div(
         .div(
-          .button("Sign me up!", .type(.submit))
+          .input(
+            .type(.hidden),
+            .name("metadata__source_page"),
+            .value(source.path.string)
+          ),
+          .button(
+            "Sign me up!",
+            .type(.submit),
+            .class(Strings.Plausible.newsletterSignupEventClass)
+          )
         )
       ),
       .div(

--- a/Sources/BrightDigitSite/Nodes/Section/PostItem+Content.swift
+++ b/Sources/BrightDigitSite/Nodes/Section/PostItem+Content.swift
@@ -127,9 +127,8 @@ extension PostItem {
         ),
 
         .form(
-          .attribute(named: "name", value: "subscribers"),
+          .action(Strings.Buttondown.subscribeURL),
           .method(.post),
-          .attribute(named: "data-netlify", value: "true"),
           .div(
             .div(
               .input(.type(.email), .name("email"), .placeholder("leo@brightdigit.com")),
@@ -138,8 +137,16 @@ extension PostItem {
           ),
           .div(
             .div(
-              .input(.type(.hidden), .name("source"), .value(source.path.string)),
-              .button(.type(.submit), .text("Sign me up!"))
+              .input(
+                .type(.hidden),
+                .name("metadata__source_page"),
+                .value(source.path.string)
+              ),
+              .button(
+                .type(.submit),
+                .class(Strings.Plausible.newsletterSignupEventClass),
+                .text("Sign me up!")
+              )
             )
           )
         )

--- a/Sources/BrightDigitSite/Strings.swift
+++ b/Sources/BrightDigitSite/Strings.swift
@@ -108,4 +108,29 @@ internal enum Strings {
       // swiftlint:disable:next line_length
       "Stay informed about the latest developments in the world of Swift App Development and what they could mean for your business."
   }
+
+  // MARK: - Buttondown
+
+  /// Buttondown newsletter endpoints for the `brightdigit` account.
+  internal enum Buttondown {
+    internal static let username = "brightdigit"
+
+    /// Embed subscribe endpoint the newsletter forms POST to.
+    internal static let subscribeURL =
+      "https://buttondown.com/api/emails/embed-subscribe/\(username)"
+
+    /// Public RSS feed for the newsletter archive.
+    internal static let rssURL = "https://buttondown.com/\(username)/rss"
+
+    /// Hosted newsletter archive page.
+    internal static let archiveURL = "https://buttondown.com/\(username)/archive"
+  }
+
+  // MARK: - Analytics
+
+  internal enum Plausible {
+    /// Plausible tagged-events class marking newsletter signup submit buttons.
+    internal static let newsletterSignupEventClass =
+      "plausible-event-name=Newsletter+Signup"
+  }
 }


### PR DESCRIPTION
Closes #126.

## Summary
Swaps the newsletter subscription from Mailchimp/Netlify over to **Buttondown** (account `brightdigit`). Pure `Sources/BrightDigitSite/` Plot-markup change — no API keys.

### The swap
- **`NewsletterItem+Content.swift` `formNode`** and **`PostItem+Content.swift` `pageFooter` form** now POST to `https://buttondown.com/api/emails/embed-subscribe/brightdigit`. Removed the Netlify-only `name="subscribers"` and `data-netlify` attributes; div/label/button structure and all CSS/Tailwind classes preserved.
- **`Node+HTML.swift`** footer `.social` newsletter link → Buttondown archive page (`/brightdigit/archive`). Adjacent `/feed.rss` icon untouched.
- **`Node+Head.swift`** head alternate feed `<link>` ("BrightDigit Newsletter") → `https://buttondown.com/brightdigit/rss`. Other site-local RSS links untouched.
- Buttondown username/URLs centralized in a new `Strings.Buttondown` enum instead of duplicated inline literals.

### Feature additions
- **A) Source-page metadata.** Both forms emit a hidden `metadata__source_page` input with the current page path. The post form's existing `source` hidden field was renamed (same value); the newsletters `formNode` threads `source.path.string` in (the item's `source` was already available, so no invasive wiring needed).
- **B) Plausible click tracking.** Base script upgraded to the tagged-events build `https://plausible.io/js/script.tagged-events.js` (kept `defer` + `data-domain`), and each submit button carries `.class("plausible-event-name=Newsletter+Signup")` (via `Strings.Plausible.newsletterSignupEventClass`).

Out of scope, left on Netlify: the `name="contact"` form in `ContactBuilder.swift`.

## Verification
- `swift build` — succeeds, zero new warnings (remaining warnings are pre-existing vendored SwiftTube deprecations). Language mode NOT lowered.
- `swift run brightdigitwg publish --mode drafts` — site generated; grepped `Output/`:
  - Buttondown `action="https://buttondown.com/api/emails/embed-subscribe/brightdigit"` present in every rendered subscribe form (newsletters index + all article/post footers).
  - `metadata__source_page` hidden inputs present with the correct per-page path (e.g. newsletters index carries `newsletters/117-…`; each article carries its own path).
  - Submit buttons carry `class="plausible-event-name=Newsletter+Signup"`.
  - Footer newsletter link → `https://buttondown.com/brightdigit/archive`; head feed link → `https://buttondown.com/brightdigit/rss`; Plausible `<script src="…/script.tagged-events.js">`.
  - No `name="subscribers"` and no plain `.../script.js` Plausible remain anywhere.

### Note for reviewer
`campaign-archive.com` still appears in the rendered **newsletter archive pages** — but only as each newsletter card's per-issue `archiveURL` (imported Mailchimp issue metadata / body content), not in any form, footer, or head template touched here. That content-side cleanup is #127/#122 territory. The only remaining `data-netlify` is the out-of-scope contact form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)