### PR TITLE
Add `import buttondown` command to import new newsletters (#122)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,7 @@ let package = Package(
       targets: ["brightdigitwg"]
     ),
     .library(name: "ContributeMailchimp", targets: ["ContributeMailchimp"]),
+    .library(name: "ContributeButtondown", targets: ["ContributeButtondown"]),
     .library(name: "BrightDigitPodcast", targets: ["BrightDigitPodcast"]),
     .library(name: "ContributeYouTube", targets: ["ContributeYouTube"]),
     .library(name: "ContributeRSS", targets: ["ContributeRSS"]),
@@ -34,6 +35,7 @@ let package = Package(
 
     .package(path: "Packages/BrightDigit/SwiftTube"),
     .package(path: "Packages/BrightDigit/Spinetail"),
+    .package(path: "Packages/BrightDigit/ButtondownKit"),
     .package(path: "Packages/BrightDigit/SyndiKit"),
     // .package(url: "https://github.com/BrightDigit/Options.git", from: "0.2.0"),
     .package(path: "Packages/BrightDigit/NPMPublishPlugin"),
@@ -68,6 +70,7 @@ let package = Package(
         "ContributeYouTube",
         "ContributeRSS",
         "ContributeMailchimp",
+        "ContributeButtondown",
         "ContributeWordPress",
         .product(name: "Spinetail", package: "Spinetail"),
         .product(name: "ConfigKeyKit", package: "ConfigKeyKit"),
@@ -99,6 +102,13 @@ let package = Package(
       ]
     ),
     .target(
+      name: "ContributeButtondown",
+      dependencies: [
+        "Contribute",
+        .product(name: "ButtondownKit", package: "ButtondownKit")
+      ]
+    ),
+    .target(
       name: "ContributeYouTube",
       dependencies: ["Contribute", "SwiftTube"]
     ),
@@ -124,6 +134,14 @@ let package = Package(
       dependencies: [
         "BrightDigitArgs",
         "BrightDigitPodcast"
+      ]
+    ),
+    .testTarget(
+      name: "ContributeButtondownTests",
+      dependencies: [
+        "ContributeButtondown",
+        "Contribute",
+        .product(name: "ButtondownKit", package: "ButtondownKit")
       ]
     )
   ]

--- a/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/ButtondownClient.swift
+++ b/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/ButtondownClient.swift
@@ -88,7 +88,7 @@ public struct ButtondownClient: Sendable, UnderlyingClientProtocol,
   /// Installs ``LenientISO8601DateTranscoder`` so the mixed fractional/whole
   /// second timestamps the Buttondown API returns both decode successfully.
   public static var defaultConfiguration: Configuration {
-    Configuration(dateTranscoder: LenientISO8601DateTranscoder())
+    Configuration(dateTranscoder: LenientISO8601DateTranscoder.default)
   }
 
   // URLSession-backed conveniences. Unavailable on WASI (no URLSessionTransport);
@@ -128,7 +128,7 @@ public struct ButtondownClient: Sendable, UnderlyingClientProtocol,
     public init(
       apiKey: String,
       serverURL: URL = ButtondownClient.defaultServerURL,
-      dateTranscoder: any DateTranscoder = LenientISO8601DateTranscoder()
+      dateTranscoder: any DateTranscoder = LenientISO8601DateTranscoder.default
     ) {
       self.init(
         apiKey: apiKey,

--- a/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/ButtondownClient.swift
+++ b/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/ButtondownClient.swift
@@ -77,6 +77,14 @@ public struct ButtondownClient: Sendable, UnderlyingClientProtocol,
     self.underlying = underlying
   }
 
+  /// The client configuration used by the URLSession-backed initializers.
+  ///
+  /// Installs ``LenientISO8601DateTranscoder`` so the mixed fractional/whole
+  /// second timestamps the Buttondown API returns both decode successfully.
+  public static var defaultConfiguration: Configuration {
+    Configuration(dateTranscoder: LenientISO8601DateTranscoder())
+  }
+
   // URLSession-backed conveniences. Unavailable on WASI (no URLSessionTransport);
   // build a `Client` with a wasm-compatible transport and use `init(underlying:)`.
   #if !os(WASI)
@@ -86,6 +94,7 @@ public struct ButtondownClient: Sendable, UnderlyingClientProtocol,
     public init(apiKey: String) throws {
       let client = Client(
         serverURL: try Servers.Server1.url(),
+        configuration: Self.defaultConfiguration,
         transport: URLSessionTransport(),
         middlewares: [AuthenticationMiddleware(apiKey: apiKey)]
       )

--- a/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/ButtondownClient.swift
+++ b/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/ButtondownClient.swift
@@ -77,6 +77,12 @@ public struct ButtondownClient: Sendable, UnderlyingClientProtocol,
     self.underlying = underlying
   }
 
+  /// The default Buttondown API server URL.
+  ///
+  /// Force-tried from the generated ``Servers/Server1``: the URL is a constant
+  /// literal in the vendored OpenAPI spec, so its construction cannot fail.
+  public static let defaultServerURL = try! Servers.Server1.url()
+
   /// The client configuration used by the URLSession-backed initializers.
   ///
   /// Installs ``LenientISO8601DateTranscoder`` so the mixed fractional/whole
@@ -88,17 +94,47 @@ public struct ButtondownClient: Sendable, UnderlyingClientProtocol,
   // URLSession-backed conveniences. Unavailable on WASI (no URLSessionTransport);
   // build a `Client` with a wasm-compatible transport and use `init(underlying:)`.
   #if !os(WASI)
-    /// Creates a client that talks to the live Buttondown API with the given key.
-    /// - Parameter apiKey: The Buttondown API key.
-    /// - Throws: An error if the server URL cannot be constructed.
-    public init(apiKey: String) throws {
-      let client = Client(
-        serverURL: try Servers.Server1.url(),
-        configuration: Self.defaultConfiguration,
-        transport: URLSessionTransport(),
-        middlewares: [AuthenticationMiddleware(apiKey: apiKey)]
+    /// Creates a client that talks to the Buttondown API with the given key,
+    /// server URL, and configuration.
+    ///
+    /// This is the designated URLSession-backed initializer; the other
+    /// `apiKey`-based initializers funnel through it.
+    /// - Parameters:
+    ///   - apiKey: The Buttondown API key.
+    ///   - serverURL: The API server URL. Defaults to ``defaultServerURL``.
+    ///   - configuration: The generated-client configuration.
+    public init(
+      apiKey: String,
+      serverURL: URL = ButtondownClient.defaultServerURL,
+      configuration: Configuration
+    ) {
+      self.init(
+        underlying: Client(
+          serverURL: serverURL,
+          configuration: configuration,
+          transport: URLSessionTransport(),
+          middlewares: [AuthenticationMiddleware(apiKey: apiKey)]
+        )
       )
-      self.init(underlying: client)
+    }
+
+    /// Creates a client that talks to the Buttondown API with the given key,
+    /// server URL, and date transcoder.
+    /// - Parameters:
+    ///   - apiKey: The Buttondown API key.
+    ///   - serverURL: The API server URL. Defaults to ``defaultServerURL``.
+    ///   - dateTranscoder: The transcoder used to decode API timestamps.
+    ///     Defaults to ``LenientISO8601DateTranscoder``.
+    public init(
+      apiKey: String,
+      serverURL: URL = ButtondownClient.defaultServerURL,
+      dateTranscoder: any DateTranscoder = LenientISO8601DateTranscoder()
+    ) {
+      self.init(
+        apiKey: apiKey,
+        serverURL: serverURL,
+        configuration: Configuration(dateTranscoder: dateTranscoder)
+      )
     }
 
     /// Creates a client using the `BUTTONDOWN_API_KEY` environment variable.
@@ -110,7 +146,7 @@ public struct ButtondownClient: Sendable, UnderlyingClientProtocol,
       else {
         throw ClientError.missingAPIKey
       }
-      return try ButtondownClient(apiKey: apiKey)
+      return ButtondownClient(apiKey: apiKey)
     }
   #endif
 }

--- a/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/LenientISO8601DateTranscoder.swift
+++ b/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/LenientISO8601DateTranscoder.swift
@@ -1,0 +1,80 @@
+//
+//  LenientISO8601DateTranscoder.swift
+//  ButtondownKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import Foundation
+import OpenAPIRuntime
+
+/// A ``DateTranscoder`` that decodes RFC-3339 / ISO-8601 timestamps whether or
+/// not they carry fractional seconds.
+///
+/// The Buttondown API mixes both forms in a single response — e.g.
+/// `creation_date` is `"2026-06-29T18:36:10.808726Z"` (fractional seconds) while
+/// `publish_date` is `"2026-06-30T12:03:00Z"` (none). OpenAPIRuntime's default
+/// ``ISO8601DateTranscoder`` is configured for exactly one shape and throws
+/// `DecodingError.dataCorrupted` on the other, which makes every real listing
+/// fail to decode. This transcoder tries the fractional-seconds parse first and
+/// falls back to the whole-second parse, so both shapes decode.
+///
+/// A fresh `ISO8601DateFormatter` is created per call, so the value carries no
+/// shared mutable state and is trivially `Sendable`.
+public struct LenientISO8601DateTranscoder: DateTranscoder {
+  /// Creates a new lenient transcoder.
+  public init() {}
+
+  /// Encodes the date as an ISO-8601 string with fractional seconds.
+  public func encode(_ date: Date) throws -> String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter.string(from: date)
+  }
+
+  /// Decodes an ISO-8601 string, tolerating the presence or absence of
+  /// fractional seconds.
+  public func decode(_ dateString: String) throws -> Date {
+    let optionSets: [ISO8601DateFormatter.Options] = [
+      [.withInternetDateTime, .withFractionalSeconds],
+      [.withInternetDateTime],
+    ]
+    let formatter = ISO8601DateFormatter()
+    for options in optionSets {
+      formatter.formatOptions = options
+      if let date = formatter.date(from: dateString) {
+        return date
+      }
+    }
+    throw DecodingError.dataCorrupted(
+      .init(
+        codingPath: [],
+        debugDescription:
+          "Expected date string to be ISO8601-formatted (with or without "
+          + "fractional seconds): \(dateString)"
+      )
+    )
+  }
+}

--- a/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/LenientISO8601DateTranscoder.swift
+++ b/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/LenientISO8601DateTranscoder.swift
@@ -46,28 +46,6 @@ import OpenAPIRuntime
 /// decoding — and the style used when encoding — are injectable, so the mixed
 /// fractional/whole-second default can be overridden for other APIs.
 public struct LenientISO8601DateTranscoder: DateTranscoder {
-  /// The error thrown when a date string matches none of the ``decodeStyles``.
-  ///
-  /// Aggregates the error from every attempted style so the failure is
-  /// diagnosable rather than collapsed into a single opaque message.
-  public struct DecodingFailure: Error, CustomStringConvertible {
-    /// The string that failed to decode.
-    public let dateString: String
-
-    /// The error thrown by each style in ``decodeStyles``, in attempt order.
-    public let underlyingErrors: [any Error]
-
-    public var description: String {
-      let reasons = underlyingErrors
-        .map { String(describing: $0) }
-        .joined(separator: "; ")
-      return
-        "Expected date string to be ISO8601-formatted matching one of "
-        + "\(underlyingErrors.count) style(s): \"\(dateString)\". "
-        + "Underlying errors: \(reasons)"
-    }
-  }
-
   /// The ISO-8601 style requiring fractional seconds (e.g. `...10.808Z`).
   private static let fractionalSecondsStyle = Date.ISO8601FormatStyle(
     includingFractionalSeconds: true
@@ -113,8 +91,9 @@ public struct LenientISO8601DateTranscoder: DateTranscoder {
   /// Decodes an ISO-8601 string by trying each style in ``decodeStyles`` until
   /// one succeeds.
   ///
-  /// - Throws: ``DecodingFailure`` aggregating every style's error when none of
-  ///   them parse the string.
+  /// - Throws: `DecodingError.dataCorrupted` when no style parses the string;
+  ///   its context aggregates every style's error in `debugDescription` and
+  ///   carries the last one as `underlyingError`.
   public func decode(_ dateString: String) throws -> Date {
     var errors: [any Error] = []
     for style in decodeStyles {
@@ -124,6 +103,16 @@ public struct LenientISO8601DateTranscoder: DateTranscoder {
         errors.append(error)
       }
     }
-    throw DecodingFailure(dateString: dateString, underlyingErrors: errors)
+    let reasons = errors.map { String(describing: $0) }.joined(separator: "; ")
+    throw DecodingError.dataCorrupted(
+      .init(
+        codingPath: [],
+        debugDescription:
+          "Expected date string to be ISO8601-formatted matching one of "
+          + "\(decodeStyles.count) style(s): \"\(dateString)\". "
+          + "Underlying errors: \(reasons)",
+        underlyingError: errors.last
+      )
+    )
   }
 }

--- a/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/LenientISO8601DateTranscoder.swift
+++ b/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/LenientISO8601DateTranscoder.swift
@@ -41,30 +41,26 @@ import OpenAPIRuntime
 /// fail to decode. This transcoder tries the fractional-seconds parse first and
 /// falls back to the whole-second parse, so both shapes decode.
 ///
-/// A fresh `ISO8601DateFormatter` is created per call, so the value carries no
-/// shared mutable state and is trivially `Sendable`.
+/// Parsing goes through the value-type `Date.ISO8601FormatStyle`, which carries
+/// no shared mutable state and is trivially `Sendable`.
 public struct LenientISO8601DateTranscoder: DateTranscoder {
   /// Creates a new lenient transcoder.
   public init() {}
 
   /// Encodes the date as an ISO-8601 string with fractional seconds.
   public func encode(_ date: Date) throws -> String {
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-    return formatter.string(from: date)
+    date.formatted(Date.ISO8601FormatStyle(includingFractionalSeconds: true))
   }
 
   /// Decodes an ISO-8601 string, tolerating the presence or absence of
   /// fractional seconds.
   public func decode(_ dateString: String) throws -> Date {
-    let optionSets: [ISO8601DateFormatter.Options] = [
-      [.withInternetDateTime, .withFractionalSeconds],
-      [.withInternetDateTime],
+    let styles = [
+      Date.ISO8601FormatStyle(includingFractionalSeconds: true),
+      Date.ISO8601FormatStyle(includingFractionalSeconds: false),
     ]
-    let formatter = ISO8601DateFormatter()
-    for options in optionSets {
-      formatter.formatOptions = options
-      if let date = formatter.date(from: dateString) {
+    for style in styles {
+      if let date = try? style.parse(dateString) {
         return date
       }
     }

--- a/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/LenientISO8601DateTranscoder.swift
+++ b/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/LenientISO8601DateTranscoder.swift
@@ -42,35 +42,88 @@ import OpenAPIRuntime
 /// falls back to the whole-second parse, so both shapes decode.
 ///
 /// Parsing goes through the value-type `Date.ISO8601FormatStyle`, which carries
-/// no shared mutable state and is trivially `Sendable`.
+/// no shared mutable state and is trivially `Sendable`. The styles tried when
+/// decoding — and the style used when encoding — are injectable, so the mixed
+/// fractional/whole-second default can be overridden for other APIs.
 public struct LenientISO8601DateTranscoder: DateTranscoder {
-  /// Creates a new lenient transcoder.
-  public init() {}
+  /// The error thrown when a date string matches none of the ``decodeStyles``.
+  ///
+  /// Aggregates the error from every attempted style so the failure is
+  /// diagnosable rather than collapsed into a single opaque message.
+  public struct DecodingFailure: Error, CustomStringConvertible {
+    /// The string that failed to decode.
+    public let dateString: String
 
-  /// Encodes the date as an ISO-8601 string with fractional seconds.
-  public func encode(_ date: Date) throws -> String {
-    date.formatted(Date.ISO8601FormatStyle(includingFractionalSeconds: true))
+    /// The error thrown by each style in ``decodeStyles``, in attempt order.
+    public let underlyingErrors: [any Error]
+
+    public var description: String {
+      let reasons = underlyingErrors
+        .map { String(describing: $0) }
+        .joined(separator: "; ")
+      return
+        "Expected date string to be ISO8601-formatted matching one of "
+        + "\(underlyingErrors.count) style(s): \"\(dateString)\". "
+        + "Underlying errors: \(reasons)"
+    }
   }
 
-  /// Decodes an ISO-8601 string, tolerating the presence or absence of
-  /// fractional seconds.
+  /// The ISO-8601 style requiring fractional seconds (e.g. `...10.808Z`).
+  private static let fractionalSecondsStyle = Date.ISO8601FormatStyle(
+    includingFractionalSeconds: true
+  )
+
+  /// The ISO-8601 style requiring whole seconds (e.g. `...10Z`).
+  private static let wholeSecondsStyle = Date.ISO8601FormatStyle(
+    includingFractionalSeconds: false
+  )
+
+  /// A transcoder covering the mixed fractional/whole-second timestamps the
+  /// Buttondown API returns: decode tries fractional seconds first and whole
+  /// seconds second; encode emits fractional seconds.
+  public static let `default` = LenientISO8601DateTranscoder(
+    decodeStyles: [fractionalSecondsStyle, wholeSecondsStyle],
+    encodeStyle: fractionalSecondsStyle
+  )
+
+  /// The styles attempted, in order, when decoding.
+  private let decodeStyles: [Date.ISO8601FormatStyle]
+
+  /// The style used when encoding.
+  private let encodeStyle: Date.ISO8601FormatStyle
+
+  /// Creates a lenient transcoder.
+  ///
+  /// - Parameters:
+  ///   - decodeStyles: The ISO-8601 styles tried, in order, when decoding.
+  ///   - encodeStyle: The style used when encoding.
+  public init(
+    decodeStyles: [Date.ISO8601FormatStyle],
+    encodeStyle: Date.ISO8601FormatStyle
+  ) {
+    self.decodeStyles = decodeStyles
+    self.encodeStyle = encodeStyle
+  }
+
+  /// Encodes the date using ``encodeStyle``.
+  public func encode(_ date: Date) throws -> String {
+    date.formatted(encodeStyle)
+  }
+
+  /// Decodes an ISO-8601 string by trying each style in ``decodeStyles`` until
+  /// one succeeds.
+  ///
+  /// - Throws: ``DecodingFailure`` aggregating every style's error when none of
+  ///   them parse the string.
   public func decode(_ dateString: String) throws -> Date {
-    let styles = [
-      Date.ISO8601FormatStyle(includingFractionalSeconds: true),
-      Date.ISO8601FormatStyle(includingFractionalSeconds: false),
-    ]
-    for style in styles {
-      if let date = try? style.parse(dateString) {
-        return date
+    var errors: [any Error] = []
+    for style in decodeStyles {
+      do {
+        return try style.parse(dateString)
+      } catch {
+        errors.append(error)
       }
     }
-    throw DecodingError.dataCorrupted(
-      .init(
-        codingPath: [],
-        debugDescription:
-          "Expected date string to be ISO8601-formatted (with or without "
-          + "fractional seconds): \(dateString)"
-      )
-    )
+    throw DecodingFailure(dateString: dateString, underlyingErrors: errors)
   }
 }

--- a/Packages/BrightDigit/ButtondownKit/Tests/ButtondownKitTests/ButtondownClientTests.swift
+++ b/Packages/BrightDigit/ButtondownKit/Tests/ButtondownKitTests/ButtondownClientTests.swift
@@ -192,9 +192,9 @@ import Testing
   }
 
   #if !os(WASI)
-    /// `init(apiKey:)` builds a live-transport client without throwing.
-    @Test internal func initWithAPIKeySucceeds() throws {
-      _ = try ButtondownClient(apiKey: Self.apiKey)
+    /// `init(apiKey:)` builds a live-transport client.
+    @Test internal func initWithAPIKeySucceeds() {
+      _ = ButtondownClient(apiKey: Self.apiKey)
     }
   #endif
 }

--- a/Packages/BrightDigit/ButtondownKit/Tests/ButtondownKitTests/Fixtures/emails-fractional.json
+++ b/Packages/BrightDigit/ButtondownKit/Tests/ButtondownKitTests/Fixtures/emails-fractional.json
@@ -1,0 +1,51 @@
+{
+  "count": 2,
+  "results": [
+    {
+      "id": "00000000-0000-0000-0000-0000000000f1",
+      "subject": "Fractional One",
+      "body": "Body with fractional creation date.",
+      "status": "sent",
+      "source": "api",
+      "commenting_mode": "enabled",
+      "archival_mode": "disabled",
+      "absolute_url": "https://buttondown.com/example/archive/fractional-one/",
+      "canonical_url": "",
+      "image": "",
+      "description": "",
+      "featured": false,
+      "should_trigger_pay_per_email_billing": false,
+      "related_email_ids": [],
+      "creation_date": "2026-06-29T18:36:10.808726Z",
+      "modification_date": "2026-06-30T12:05:51.860935Z",
+      "filters": {
+        "predicate": "and",
+        "filters": [],
+        "groups": []
+      }
+    },
+    {
+      "id": "00000000-0000-0000-0000-0000000000f2",
+      "subject": "Whole Second Two",
+      "body": "Body with whole-second creation date.",
+      "status": "sent",
+      "source": "api",
+      "commenting_mode": "enabled",
+      "archival_mode": "disabled",
+      "absolute_url": "https://buttondown.com/example/archive/whole-second-two/",
+      "canonical_url": "",
+      "image": "",
+      "description": "",
+      "featured": false,
+      "should_trigger_pay_per_email_billing": false,
+      "related_email_ids": [],
+      "creation_date": "2026-06-30T12:03:00Z",
+      "modification_date": "2026-06-30T12:03:00Z",
+      "filters": {
+        "predicate": "and",
+        "filters": [],
+        "groups": []
+      }
+    }
+  ]
+}

--- a/Packages/BrightDigit/ButtondownKit/Tests/ButtondownKitTests/LenientISO8601DateTranscoderTests.swift
+++ b/Packages/BrightDigit/ButtondownKit/Tests/ButtondownKitTests/LenientISO8601DateTranscoderTests.swift
@@ -1,0 +1,96 @@
+//
+//  LenientISO8601DateTranscoderTests.swift
+//  ButtondownKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import Foundation
+import OpenAPIRuntime
+import Testing
+
+@testable import ButtondownKit
+
+/// Verifies the lenient date transcoder decodes the mixed timestamp shapes the
+/// Buttondown API returns, both directly and end-to-end through a listing.
+@Suite internal struct LenientISO8601DateTranscoderTests {
+  private static let apiKey = "FAKE_KEY"
+
+  /// Loads a JSON fixture from the test bundle's copied `Fixtures` directory.
+  private func fixture(_ name: String) throws -> String {
+    let url = try #require(
+      Bundle.module.url(
+        forResource: name,
+        withExtension: "json",
+        subdirectory: "Fixtures"
+      ),
+      "missing fixture \(name).json"
+    )
+    return try String(contentsOf: url, encoding: .utf8)
+  }
+
+  /// A timestamp with fractional seconds decodes to the expected instant.
+  @Test internal func decodesFractionalSeconds() throws {
+    let transcoder = LenientISO8601DateTranscoder()
+    let date = try transcoder.decode("2026-06-29T18:36:10.808726Z")
+    // 2026-06-29T18:36:10Z is 1_782_758_170 seconds since the epoch; the
+    // fractional part adds within the same second.
+    #expect(abs(date.timeIntervalSince1970 - 1_782_758_170.808) < 0.01)
+  }
+
+  /// A timestamp with no fractional seconds still decodes (the fallback path).
+  @Test internal func decodesWholeSeconds() throws {
+    let transcoder = LenientISO8601DateTranscoder()
+    let date = try transcoder.decode("2026-06-30T12:03:00Z")
+    #expect(date.timeIntervalSince1970 == 1_782_820_980)
+  }
+
+  /// A non-ISO8601 string throws rather than returning a bogus date.
+  @Test internal func rejectsGarbage() {
+    let transcoder = LenientISO8601DateTranscoder()
+    #expect(throws: (any Error).self) {
+      _ = try transcoder.decode("not-a-date")
+    }
+  }
+
+  /// Round-trips a fixture whose timestamps mix fractional and whole seconds
+  /// through a real generated `Client` — the shape that previously failed to
+  /// decode against the live API.
+  @Test internal func listAllEmailsDecodesMixedTimestamps() async throws {
+    let transport = MockTransport(responses: [
+      "GET /emails": [.init(status: 200, json: try fixture("emails-fractional"))]
+    ])
+    let generated = Client(
+      serverURL: try Servers.Server1.url(),
+      configuration: ButtondownClient.defaultConfiguration,
+      transport: transport,
+      middlewares: [AuthenticationMiddleware(apiKey: Self.apiKey)]
+    )
+    let client = ButtondownClient(underlying: generated)
+    let emails = try await client.listAllEmails(status: [.sent])
+    #expect(emails.count == 2)
+    #expect(emails.map(\.subject) == ["Fractional One", "Whole Second Two"])
+  }
+}

--- a/Packages/BrightDigit/ButtondownKit/Tests/ButtondownKitTests/LenientISO8601DateTranscoderTests.swift
+++ b/Packages/BrightDigit/ButtondownKit/Tests/ButtondownKitTests/LenientISO8601DateTranscoderTests.swift
@@ -53,7 +53,7 @@ import Testing
 
   /// A timestamp with fractional seconds decodes to the expected instant.
   @Test internal func decodesFractionalSeconds() throws {
-    let transcoder = LenientISO8601DateTranscoder()
+    let transcoder = LenientISO8601DateTranscoder.default
     let date = try transcoder.decode("2026-06-29T18:36:10.808726Z")
     // 2026-06-29T18:36:10Z is 1_782_758_170 seconds since the epoch; the
     // fractional part adds within the same second.
@@ -62,14 +62,14 @@ import Testing
 
   /// A timestamp with no fractional seconds still decodes (the fallback path).
   @Test internal func decodesWholeSeconds() throws {
-    let transcoder = LenientISO8601DateTranscoder()
+    let transcoder = LenientISO8601DateTranscoder.default
     let date = try transcoder.decode("2026-06-30T12:03:00Z")
     #expect(date.timeIntervalSince1970 == 1_782_820_980)
   }
 
   /// A non-ISO8601 string throws rather than returning a bogus date.
   @Test internal func rejectsGarbage() {
-    let transcoder = LenientISO8601DateTranscoder()
+    let transcoder = LenientISO8601DateTranscoder.default
     #expect(throws: (any Error).self) {
       _ = try transcoder.decode("not-a-date")
     }

--- a/Sources/BrightDigitArgs/Config/CommandDispatcher.swift
+++ b/Sources/BrightDigitArgs/Config/CommandDispatcher.swift
@@ -53,6 +53,7 @@ public enum CommandDispatcher {
     await registry.register(EpisodeURLCommand.self)
     await registry.register(Import.PodcastCommand.self)
     await registry.register(Import.MailchimpCommand.self)
+    await registry.register(Import.ButtondownCommand.self)
     await registry.register(Import.WordPressCommand.self)
 
     // argv after the executable name.

--- a/Sources/BrightDigitArgs/Config/Import.ButtondownCommand+Selection.swift
+++ b/Sources/BrightDigitArgs/Config/Import.ButtondownCommand+Selection.swift
@@ -1,0 +1,100 @@
+//
+//  Import.ButtondownCommand+Selection.swift
+//  BrightDigit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import BrightDigitSite
+import ButtondownKit
+import Contribute
+import ContributeButtondown
+import Foundation
+
+extension Import.ButtondownCommand {
+  /// The image used when a Buttondown email supplies no preview image, so the
+  /// site's required `featuredImage` metadata is always present.
+  private static let featuredImageFallback: URL = {
+    guard
+      let url = URL(string: "https://brightdigit.com/android-chrome-512x512.png")
+    else {
+      preconditionFailure("Invalid featuredImage fallback URL")
+    }
+    return url
+  }()
+
+  /// Logs an `import buttondown:` diagnostic line to stderr.
+  internal static func logImport(_ message: String) {
+    FileHandle.standardError.write(Data("import buttondown: \(message)\n".utf8))
+  }
+
+  /// Builds a Buttondown client, preferring the explicit key and otherwise
+  /// falling back to the `BUTTONDOWN_API_KEY` environment variable.
+  internal static func makeClient(apiKey: String?) throws -> ButtondownClient {
+    if let apiKey, !apiKey.isEmpty {
+      return try ButtondownClient(apiKey: apiKey)
+    }
+    return try ButtondownClient.fromEnvironment()
+  }
+
+  /// The `NNN-slug` file name (without extension) for a source.
+  internal static func fileNameWithoutExtensionFromSource(
+    _ source: ContributeButtondown.Newsletter.Source
+  ) -> String {
+    let paddedIssue = source.issueNo.description.padLeft(totalWidth: 3, byString: "0")
+    return "\(paddedIssue)-\(source.slug)"
+  }
+
+  /// The set of issue numbers already present in `directory`, read from the
+  /// zero-padded `NNN-` file-name prefix (slug-independent), matching the naming
+  /// the Mailchimp importer produced. Used to skip issues already on disk.
+  internal static func existingIssueNumbers(in directory: URL) -> Set<Int> {
+    let names =
+      (try? FileManager.default.contentsOfDirectory(atPath: directory.path)) ?? []
+    var numbers: Set<Int> = []
+    for name in names where name.hasSuffix(".md") {
+      let prefix = name.prefix { $0.isNumber }
+      if prefix.count >= 1, let issueNo = Int(prefix) {
+        numbers.insert(issueNo)
+      }
+    }
+    return numbers
+  }
+
+  /// Resolves a numbered email into a writable ``Newsletter/Source``, deriving
+  /// the slug from the subject (via ``BrightDigitSite``'s `convertedToSlug()`).
+  internal static func source(
+    from numbered: ContributeButtondown.Newsletter.NumberedEmail
+  ) throws -> ContributeButtondown.Newsletter.Source {
+    let slug = numbered.email.subject.convertedToSlug()
+    logImport("#\(numbered.issueNo) ← \(numbered.email.subject)")
+    return try ContributeButtondown.Newsletter.Source(
+      email: numbered.email,
+      issueNo: numbered.issueNo,
+      slug: slug,
+      featuredImageFallback: featuredImageFallback
+    )
+  }
+}

--- a/Sources/BrightDigitArgs/Config/Import.ButtondownCommand+Selection.swift
+++ b/Sources/BrightDigitArgs/Config/Import.ButtondownCommand+Selection.swift
@@ -54,7 +54,7 @@ extension Import.ButtondownCommand {
   /// falling back to the `BUTTONDOWN_API_KEY` environment variable.
   internal static func makeClient(apiKey: String?) throws -> ButtondownClient {
     if let apiKey, !apiKey.isEmpty {
-      return try ButtondownClient(apiKey: apiKey)
+      return ButtondownClient(apiKey: apiKey)
     }
     return try ButtondownClient.fromEnvironment()
   }

--- a/Sources/BrightDigitArgs/Config/Import.ButtondownCommand.swift
+++ b/Sources/BrightDigitArgs/Config/Import.ButtondownCommand.swift
@@ -1,0 +1,171 @@
+//
+//  Import.ButtondownCommand.swift
+//  BrightDigit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import BrightDigitSite
+import ButtondownKit
+import ConfigKeyKit
+import Configuration
+import Contribute
+import ContributeButtondown
+import Foundation
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+extension Import.ButtondownCommand {
+  /// Resolved configuration for the `import buttondown` command.
+  public struct Config: ConfigurationParseable {
+    public typealias ConfigReader = Configuration.ConfigReader
+    public typealias BaseConfig = Never
+
+    internal let exportMarkdownDirectory: String
+    internal let buttondownAPIKey: String?
+    internal let overwriteExisting: Bool
+    internal let includeMissingPrevious: Bool
+
+    public init(
+      configuration reader: Configuration.ConfigReader,
+      base _: Never?
+    ) async throws {
+      guard let exportMarkdownDirectory = reader.read(Keys.exportMarkdownDirectory)
+      else {
+        throw CommandError.missingRequiredOption("--export-markdown-directory")
+      }
+      self.exportMarkdownDirectory = exportMarkdownDirectory
+
+      // Optional: falls back to BUTTONDOWN_API_KEY via
+      // `ButtondownClient.fromEnvironment()` when the flag is absent.
+      self.buttondownAPIKey = reader.read(Keys.buttondownAPIKey)
+
+      self.overwriteExisting = reader.read(Keys.overwriteExisting)
+      self.includeMissingPrevious = reader.read(Keys.includeMissingPrevious)
+    }
+  }
+
+  private enum Keys {
+    static let exportMarkdownDirectory = OptionalConfigKey<String>(
+      "export-markdown-directory"
+    )
+    static let buttondownAPIKey = OptionalConfigKey<String>(
+      "buttondown-api-key"
+    )
+    static let overwriteExisting = ConfigKey(
+      "overwrite-existing", default: false
+    )
+    static let includeMissingPrevious = ConfigKey(
+      "include-missing-previous", default: false
+    )
+  }
+
+  /// Lists sent Buttondown emails, assigns issue numbers continuing from the
+  /// local archive, skips issues already on disk, and writes Markdown files for
+  /// the new ones only.
+  public func execute() async throws {
+    let contentPathURL = URL(fileURLWithPath: config.exportMarkdownDirectory)
+    let client = try Self.makeClient(apiKey: config.buttondownAPIKey)
+    let htmlToMarkdown = Import.markdownGenerator.markdown(fromHTML:)
+
+    // Only fully-sent emails are real published issues.
+    let emails = try await client.listAllEmails(status: [.sent], pageLimit: nil)
+
+    let existing = Self.existingIssueNumbers(in: contentPathURL)
+    let localMax = existing.max() ?? 0
+    let skip = config.overwriteExisting ? [] : existing
+
+    let numbered = Newsletter.newIssues(
+      from: emails,
+      continuingFrom: localMax,
+      existingIssueNumbers: skip
+    )
+
+    let alreadyPresent = emails.count - numbered.count
+    if alreadyPresent > 0 {
+      Self.logImport(
+        "\(alreadyPresent) already on disk; importing \(numbered.count) new issue(s)."
+      )
+    }
+
+    let sources = try numbered.map { try Self.source(from: $0) }
+      .sorted { $0.issueNo < $1.issueNo }
+
+    let options = MarkdownContentBuilderOptions(
+      shouldOverwriteExisting: config.overwriteExisting,
+      includeMissingPrevious: config.includeMissingPrevious
+    )
+
+    try Newsletter.write(
+      from: sources,
+      atContentPathURL: contentPathURL,
+      fileNameWithoutExtension: Self.fileNameWithoutExtensionFromSource(_:),
+      using: htmlToMarkdown,
+      options: options
+    )
+  }
+}
+
+extension Import {
+  /// ConfigKeyKit-based command for importing Buttondown newsletters (issue #122).
+  ///
+  /// Registers under the two-token name `import buttondown` and is dispatched by
+  /// ``CommandDispatcher``. Lists the newsletter's sent emails, assigns each an
+  /// issue number (continuing the local archive past issue 117), skips any issue
+  /// already present locally, and writes `NNN-slug.md` for the new issues only.
+  /// It writes ONLY local `Content/newsletters/*.md` — the operation is
+  /// reversible with `git checkout`.
+  public struct ButtondownCommand: ConfigKeyKit.Command {
+    public static let commandName = "import buttondown"
+    public static let abstract =
+      "Command for importing newly-published Buttondown newsletters into the site."
+    public static let helpText = """
+      OVERVIEW: Import newly-published Buttondown newsletters into the BrightDigit site.
+
+      USAGE: brightdigitwg import buttondown --export-markdown-directory <dir> \
+      [--buttondown-api-key <key>] [--overwrite-existing] [--include-missing-previous]
+
+      OPTIONS:
+        --export-markdown-directory <dir> Destination directory for markdown files. \
+      (required)
+        --buttondown-api-key <key>        Buttondown API key. Falls back to the \
+      BUTTONDOWN_API_KEY environment variable when omitted.
+        --overwrite-existing              Overwrite existing markdown files.
+        --include-missing-previous        Include newsletters missing a previous entry.
+        -h, --help                        Show help information.
+
+      Each option may also be supplied via an uppercased, underscore-separated
+      environment variable (e.g. BUTTONDOWN_API_KEY).
+      """
+
+    private let config: Config
+
+    public init(config: Config) {
+      self.config = config
+    }
+  }
+}

--- a/Sources/ContributeButtondown/ButtondownImportError.swift
+++ b/Sources/ContributeButtondown/ButtondownImportError.swift
@@ -1,0 +1,34 @@
+//
+//  ButtondownImportError.swift
+//  BrightDigit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+/// Errors raised while importing Buttondown newsletters into local Markdown.
+public enum ButtondownImportError: Error, Equatable, Sendable {
+  /// An email's `absolute_url` could not be parsed into a `URL`.
+  case malformedArchiveURL(emailID: String, value: String)
+}

--- a/Sources/ContributeButtondown/FrontMatter.swift
+++ b/Sources/ContributeButtondown/FrontMatter.swift
@@ -1,0 +1,61 @@
+//
+//  FrontMatter.swift
+//  BrightDigit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import Foundation
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+extension Newsletter {
+  /// The YAML front matter emitted for a Buttondown newsletter issue.
+  ///
+  /// The field set mirrors what `Sources/BrightDigitSite`'s `NewsletterItem`
+  /// reads: `issueNo`, `title`, `date`, `description`, `featuredImage`
+  /// (required by `ItemMetadata`), and `longArchiveURL` (the newsletter's
+  /// redirect target). ``buttondownID`` is retained for provenance/reversibility
+  /// and is ignored by the site (unknown metadata keys are tolerated), the same
+  /// way the Mailchimp importer retained `campaignID`.
+  public struct FrontMatter: Codable, Equatable, Sendable {
+    /// The assigned issue number.
+    public let issueNo: Int
+    /// The originating Buttondown email id.
+    public let buttondownID: String
+    /// The featured/preview image URL.
+    public let featuredImage: URL
+    /// The canonical archive URL of the issue.
+    public let longArchiveURL: URL
+    /// The issue title (email subject).
+    public let title: String
+    /// The published date, pre-formatted via ``Contribute/YAML/dateFormatter``.
+    public let date: String
+    /// The issue description.
+    public let description: String
+  }
+}

--- a/Sources/ContributeButtondown/FrontMatterTranslator.swift
+++ b/Sources/ContributeButtondown/FrontMatterTranslator.swift
@@ -1,0 +1,56 @@
+//
+//  FrontMatterTranslator.swift
+//  BrightDigit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import Contribute
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+extension Newsletter {
+  /// Translates a Buttondown newsletter ``Source`` into its ``FrontMatter``.
+  public struct FrontMatterTranslator: Contribute.FrontMatterTranslator {
+    public typealias FrontMatterType = FrontMatter
+    public typealias SourceType = Source
+
+    public init() {}
+
+    public func frontMatter(from source: Source) -> FrontMatter {
+      FrontMatter(
+        issueNo: source.issueNo,
+        buttondownID: source.buttondownID,
+        featuredImage: source.featuredImageURL,
+        longArchiveURL: source.longArchiveURL,
+        title: source.title,
+        date: YAML.dateFormatter.string(from: source.date),
+        description: source.description
+      )
+    }
+  }
+}

--- a/Sources/ContributeButtondown/IssueNumbering.swift
+++ b/Sources/ContributeButtondown/IssueNumbering.swift
@@ -1,0 +1,131 @@
+//
+//  IssueNumbering.swift
+//  BrightDigit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import ButtondownKit
+import Foundation
+
+extension Newsletter {
+  /// A Buttondown email paired with the issue number assigned to it.
+  public struct NumberedEmail: Sendable, Equatable {
+    /// The source Buttondown email.
+    public let email: Email
+    /// The issue number assigned by ``Newsletter/assignIssueNumbers(to:continuingFrom:)``.
+    public let issueNo: Int
+
+    /// Memberwise initializer.
+    public init(email: Email, issueNo: Int) {
+      self.email = email
+      self.issueNo = issueNo
+    }
+  }
+
+  // Captures the issue number that follows the word "Issue" (case-insensitive),
+  // with an optional `#`: matches "Issue 118", "Issue #118", and the
+  // "… - Issue #118 - …" form the BrightDigit newsletter subjects use. Numbers
+  // that don't follow "Issue" (e.g. a version like "Bushel v2.3.0") are
+  // deliberately ignored, so those emails fall back to sequential numbering.
+  private static let issueNoRegexPatternString = #"(?i)issue\s*#?\s*(\d+)"#
+
+  private static let issueNoRegex: NSRegularExpression = {
+    do {
+      return try NSRegularExpression(pattern: issueNoRegexPatternString, options: [])
+    } catch {
+      preconditionFailure("Invalid issueNoRegex pattern: \(error)")
+    }
+  }()
+
+  /// Parses an explicit issue number from an email subject, if present.
+  ///
+  /// - Parameter subject: The email subject line.
+  /// - Returns: The number following "Issue" (optionally `#`), or `nil` when the
+  ///   subject carries no such marker.
+  public static func parseIssueNumber(fromSubject subject: String) -> Int? {
+    let range = NSRange(subject.startIndex..<subject.endIndex, in: subject)
+    guard
+      let match = issueNoRegex.firstMatch(in: subject, options: [], range: range),
+      match.numberOfRanges > 1,
+      let numberRange = Range(match.range(at: 1), in: subject),
+      let issueNumber = Int(subject[numberRange])
+    else {
+      return nil
+    }
+    return issueNumber
+  }
+
+  /// Assigns an issue number to each email, oldest-first.
+  ///
+  /// Numbering needs global ordering, so this sorts the emails by
+  /// `creationDate` ascending and walks them once. An email whose subject
+  /// carries an explicit "Issue N" marker keeps that number; an unnumbered email
+  /// takes the next sequential number, continuing from `localMaxIssueNo` and any
+  /// higher explicit number already seen. This continues the local archive
+  /// (which ends at issue 117) as 118, 119, … while honoring explicit numbers
+  /// when Buttondown provides them.
+  ///
+  /// - Parameters:
+  ///   - emails: The Buttondown emails to number (typically the `.sent` ones).
+  ///   - localMaxIssueNo: The highest issue number already present locally.
+  /// - Returns: One ``NumberedEmail`` per input email, in oldest-first order.
+  public static func assignIssueNumbers(
+    to emails: [Email],
+    continuingFrom localMaxIssueNo: Int
+  ) -> [NumberedEmail] {
+    let ordered = emails.sorted { $0.creationDate < $1.creationDate }
+    var maxAssigned = localMaxIssueNo
+    var result: [NumberedEmail] = []
+    for email in ordered {
+      let issueNo: Int
+      if let explicit = parseIssueNumber(fromSubject: email.subject) {
+        issueNo = explicit
+      } else {
+        issueNo = maxAssigned + 1
+      }
+      maxAssigned = max(maxAssigned, issueNo)
+      result.append(NumberedEmail(email: email, issueNo: issueNo))
+    }
+    return result
+  }
+
+  /// Numbers the emails, then keeps only those whose issue number is not already
+  /// present locally — the new issues to import (118+ for the current archive).
+  ///
+  /// - Parameters:
+  ///   - emails: The Buttondown emails to number.
+  ///   - localMaxIssueNo: The highest issue number already present locally.
+  ///   - existingIssueNumbers: Issue numbers already on disk, to skip.
+  /// - Returns: The numbered emails not already present, in oldest-first order.
+  public static func newIssues(
+    from emails: [Email],
+    continuingFrom localMaxIssueNo: Int,
+    existingIssueNumbers: Set<Int>
+  ) -> [NumberedEmail] {
+    assignIssueNumbers(to: emails, continuingFrom: localMaxIssueNo)
+      .filter { !existingIssueNumbers.contains($0.issueNo) }
+  }
+}

--- a/Sources/ContributeButtondown/Newsletter.swift
+++ b/Sources/ContributeButtondown/Newsletter.swift
@@ -1,0 +1,45 @@
+//
+//  Newsletter.swift
+//  BrightDigit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import Contribute
+
+/// The newsletter content type, importing BrightDigit newsletters from
+/// Buttondown emails (issue #122).
+///
+/// A fresh, non-deprecated analog of `ContributeMailchimp.Newsletter`. Where the
+/// Mailchimp importer fetched each campaign's archive HTML in a second request,
+/// a Buttondown ``ButtondownKit/Email`` already carries its `body` HTML, so a
+/// ``Source`` is built directly from the email and its `body` is converted to
+/// Markdown through the shared HTML→Markdown closure by the reused
+/// ``Contribute/FilteredHTMLMarkdownExtractor``.
+public enum Newsletter: ContentType {
+  public typealias SourceType = Source
+  public typealias MarkdownExtractorType = FilteredHTMLMarkdownExtractor<Source>
+  public typealias FrontMatterTranslatorType = FrontMatterTranslator
+}

--- a/Sources/ContributeButtondown/Source.swift
+++ b/Sources/ContributeButtondown/Source.swift
@@ -1,0 +1,131 @@
+//
+//  Source.swift
+//  BrightDigit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import ButtondownKit
+import Contribute
+import Foundation
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+extension Newsletter {
+  /// A fully-resolved Buttondown newsletter issue: the email metadata plus an
+  /// assigned issue number and a slug, ready to be written to Markdown.
+  ///
+  /// Conforms to ``Contribute/HTMLSource`` so the reused
+  /// ``Contribute/FilteredHTMLMarkdownExtractor`` can pull ``html`` (the email
+  /// body) and run it through the shared HTML→Markdown converter.
+  public struct Source: HTMLSource, Sendable {
+    /// The URL-safe slug used for the file name (`NNN-slug.md`).
+    public let slug: String
+    /// The assigned issue number (see ``IssueNumbering``).
+    public let issueNo: Int
+    /// The Buttondown email id (a TypeID).
+    public let buttondownID: String
+    /// The canonical archive URL of the email on the newsletter's web archive.
+    public let longArchiveURL: URL
+    /// The preview/featured image URL (resolved to a fallback when the email
+    /// supplied none, so the site's required `featuredImage` is always present).
+    public let featuredImageURL: URL
+    /// The email subject line, used as the front-matter `title`.
+    public let title: String
+    /// The email's human-readable description, used as the `description`.
+    public let description: String
+    /// The email's creation date, used as the published `date`.
+    public let date: Date
+    /// The email body HTML, converted to Markdown by the extractor.
+    public let html: String
+
+    /// Memberwise initializer.
+    public init(
+      slug: String,
+      issueNo: Int,
+      buttondownID: String,
+      longArchiveURL: URL,
+      featuredImageURL: URL,
+      title: String,
+      description: String,
+      date: Date,
+      html: String
+    ) {
+      self.slug = slug
+      self.issueNo = issueNo
+      self.buttondownID = buttondownID
+      self.longArchiveURL = longArchiveURL
+      self.featuredImageURL = featuredImageURL
+      self.title = title
+      self.description = description
+      self.date = date
+      self.html = html
+    }
+  }
+}
+
+extension Newsletter.Source {
+  /// Builds a ``Newsletter/Source`` from a Buttondown ``ButtondownKit/Email``.
+  ///
+  /// The email's `body` HTML is carried verbatim (converted to Markdown later by
+  /// the extractor). `absoluteURL` becomes the archive link; an empty `image`
+  /// falls back to `featuredImageFallback`.
+  ///
+  /// - Parameters:
+  ///   - email: The Buttondown email to import.
+  ///   - issueNo: The issue number assigned to this email.
+  ///   - slug: The URL-safe slug for the file name.
+  ///   - featuredImageFallback: The image URL to use when the email has none.
+  /// - Throws: ``ButtondownImportError/malformedArchiveURL`` if `absoluteURL`
+  ///   cannot be parsed into a `URL`.
+  public init(
+    email: Email,
+    issueNo: Int,
+    slug: String,
+    featuredImageFallback: URL
+  ) throws {
+    guard let longArchiveURL = URL(string: email.absoluteURL) else {
+      throw ButtondownImportError.malformedArchiveURL(
+        emailID: email.id, value: email.absoluteURL
+      )
+    }
+    let featuredImageURL = email.image.isEmpty
+      ? featuredImageFallback
+      : URL(string: email.image) ?? featuredImageFallback
+    self.init(
+      slug: slug,
+      issueNo: issueNo,
+      buttondownID: email.id,
+      longArchiveURL: longArchiveURL,
+      featuredImageURL: featuredImageURL,
+      title: email.subject,
+      description: email.description,
+      date: email.creationDate,
+      html: email.body
+    )
+  }
+}

--- a/Tests/ContributeButtondownTests/Fixtures.swift
+++ b/Tests/ContributeButtondownTests/Fixtures.swift
@@ -1,0 +1,59 @@
+//
+//  Fixtures.swift
+//  BrightDigit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import ButtondownKit
+import Foundation
+
+/// Constructed ``ButtondownKit/Email`` values for offline tests (no network).
+internal enum Fixtures {
+  /// Builds a sent email `daysAfterEpoch` days after the reference date, so
+  /// tests can control creation-date ordering deterministically.
+  internal static func email(
+    subject: String,
+    daysAfterEpoch: Int,
+    id: String = UUID().uuidString,
+    body: String = "<p>Body</p>",
+    absoluteURL: String = "https://buttondown.com/brightdigit/archive/example/",
+    description: String = "An example issue.",
+    image: String = ""
+  ) -> Email {
+    let date = Date(timeIntervalSince1970: TimeInterval(daysAfterEpoch) * 86_400)
+    return Email(
+      id: id,
+      subject: subject,
+      body: body,
+      status: .sent,
+      creationDate: date,
+      modificationDate: date,
+      absoluteURL: absoluteURL,
+      description: description,
+      image: image
+    )
+  }
+}

--- a/Tests/ContributeButtondownTests/IssueNumberingTests.swift
+++ b/Tests/ContributeButtondownTests/IssueNumberingTests.swift
@@ -1,0 +1,112 @@
+//
+//  IssueNumberingTests.swift
+//  BrightDigit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import ButtondownKit
+import Foundation
+import Testing
+
+@testable import ContributeButtondown
+
+/// Exercises subject parsing, sequential numbering, and the skip-existing logic.
+@Suite internal struct IssueNumberingTests {
+  /// "Issue N" and "Issue #N" (including the interior "- Issue #N -" form) parse
+  /// out the number; version strings and empty subjects do not.
+  @Test internal func parseIssueNumberVariants() {
+    #expect(Newsletter.parseIssueNumber(fromSubject: "Issue 118") == 118)
+    #expect(Newsletter.parseIssueNumber(fromSubject: "Issue #119") == 119)
+    #expect(
+      Newsletter.parseIssueNumber(
+        fromSubject: "BrightDigit Newsletter - Issue #120 - 26.01.15"
+      ) == 120
+    )
+    #expect(
+      Newsletter.parseIssueNumber(fromSubject: "issue   #121  extra") == 121
+    )
+    #expect(Newsletter.parseIssueNumber(fromSubject: "Bushel v2.3.0 released") == nil)
+    #expect(Newsletter.parseIssueNumber(fromSubject: "Introducing swift-build") == nil)
+    #expect(Newsletter.parseIssueNumber(fromSubject: "") == nil)
+  }
+
+  /// Explicit subject numbers win; unnumbered emails take the next sequential
+  /// number continuing from the local max — assigned oldest-first regardless of
+  /// input order.
+  @Test internal func assignsNumbersOldestFirst() {
+    let emails = [
+      Fixtures.email(subject: "Unnumbered launch", daysAfterEpoch: 3),
+      Fixtures.email(subject: "Issue #118", daysAfterEpoch: 1),
+      Fixtures.email(subject: "Another unnumbered", daysAfterEpoch: 2),
+    ]
+    let numbered = Newsletter.assignIssueNumbers(to: emails, continuingFrom: 117)
+    // Ordered oldest-first: #118 (explicit), then 119, 120 sequential.
+    #expect(numbered.map(\.issueNo) == [118, 119, 120])
+    #expect(
+      numbered.map(\.email.subject) == [
+        "Issue #118", "Another unnumbered", "Unnumbered launch",
+      ]
+    )
+  }
+
+  /// An explicit number higher than the running max advances the sequential
+  /// counter, so a later unnumbered email continues past it.
+  @Test internal func explicitNumberAdvancesSequentialCounter() {
+    let emails = [
+      Fixtures.email(subject: "Issue #125", daysAfterEpoch: 1),
+      Fixtures.email(subject: "No number here", daysAfterEpoch: 2),
+    ]
+    let numbered = Newsletter.assignIssueNumbers(to: emails, continuingFrom: 117)
+    #expect(numbered.map(\.issueNo) == [125, 126])
+  }
+
+  /// `newIssues` drops issue numbers already present locally, keeping only the
+  /// genuinely new ones.
+  @Test internal func newIssuesSkipsExisting() {
+    let emails = [
+      Fixtures.email(subject: "Issue #117", daysAfterEpoch: 1),
+      Fixtures.email(subject: "Issue #118", daysAfterEpoch: 2),
+      Fixtures.email(subject: "Issue #119", daysAfterEpoch: 3),
+    ]
+    let result = Newsletter.newIssues(
+      from: emails,
+      continuingFrom: 117,
+      existingIssueNumbers: [117]
+    )
+    #expect(result.map(\.issueNo) == [118, 119])
+  }
+
+  /// With no explicit numbers at all, the whole batch is numbered sequentially
+  /// from the local max.
+  @Test internal func allUnnumberedSequentialFromMax() {
+    let emails = [
+      Fixtures.email(subject: "One", daysAfterEpoch: 1),
+      Fixtures.email(subject: "Two", daysAfterEpoch: 2),
+    ]
+    let numbered = Newsletter.assignIssueNumbers(to: emails, continuingFrom: 117)
+    #expect(numbered.map(\.issueNo) == [118, 119])
+  }
+}

--- a/Tests/ContributeButtondownTests/NewsletterTranslationTests.swift
+++ b/Tests/ContributeButtondownTests/NewsletterTranslationTests.swift
@@ -1,0 +1,136 @@
+//
+//  NewsletterTranslationTests.swift
+//  BrightDigit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import ButtondownKit
+import Contribute
+import Foundation
+import Testing
+
+@testable import ContributeButtondown
+
+/// Exercises `Email → Source → FrontMatter` mapping and the full content build.
+@Suite internal struct NewsletterTranslationTests {
+  private static let fallbackImage = URL(
+    string: "https://brightdigit.com/android-chrome-512x512.png"
+  )!
+
+  /// A `Source` built from an email carries the email fields, and the translator
+  /// maps them onto the front matter (with the date formatted via `YAML`).
+  @Test internal func translatesSourceToFrontMatter() throws {
+    let email = Fixtures.email(
+      subject: "Issue #118",
+      daysAfterEpoch: 100,
+      id: "abc-123",
+      body: "<h1>Hello</h1>",
+      absoluteURL: "https://buttondown.com/brightdigit/archive/issue-118/",
+      description: "The 118th issue.",
+      image: "https://example.com/cover.png"
+    )
+    let source = try Newsletter.Source(
+      email: email,
+      issueNo: 118,
+      slug: "issue-118",
+      featuredImageFallback: Self.fallbackImage
+    )
+    let frontMatter = Newsletter.FrontMatterTranslator().frontMatter(from: source)
+
+    #expect(frontMatter.issueNo == 118)
+    #expect(frontMatter.buttondownID == "abc-123")
+    #expect(frontMatter.title == "Issue #118")
+    #expect(frontMatter.description == "The 118th issue.")
+    #expect(
+      frontMatter.longArchiveURL
+        == URL(string: "https://buttondown.com/brightdigit/archive/issue-118/")
+    )
+    #expect(frontMatter.featuredImage == URL(string: "https://example.com/cover.png"))
+    #expect(frontMatter.date == YAML.dateFormatter.string(from: email.creationDate))
+    // The body HTML is retained on the source for the extractor to convert.
+    #expect(source.html == "<h1>Hello</h1>")
+  }
+
+  /// An email with no image falls back to the supplied featured image, so the
+  /// site's required `featuredImage` metadata is always emitted.
+  @Test internal func emptyImageFallsBack() throws {
+    let email = Fixtures.email(subject: "Issue #119", daysAfterEpoch: 101, image: "")
+    let source = try Newsletter.Source(
+      email: email,
+      issueNo: 119,
+      slug: "issue-119",
+      featuredImageFallback: Self.fallbackImage
+    )
+    #expect(source.featuredImageURL == Self.fallbackImage)
+  }
+
+  /// A malformed `absolute_url` surfaces as a typed import error rather than a
+  /// silent bad URL.
+  @Test internal func malformedArchiveURLThrows() {
+    let email = Fixtures.email(
+      subject: "Issue #120",
+      daysAfterEpoch: 102,
+      id: "bad-url",
+      absoluteURL: ""
+    )
+    #expect(throws: ButtondownImportError.malformedArchiveURL(emailID: "bad-url", value: "")) {
+      _ = try Newsletter.Source(
+        email: email,
+        issueNo: 120,
+        slug: "issue-120",
+        featuredImageFallback: Self.fallbackImage
+      )
+    }
+  }
+
+  /// The full content build emits YAML front matter (delimited by `---`) with
+  /// the mapped fields, followed by the Markdown body from the HTML converter.
+  @Test internal func buildsMarkdownWithFrontMatter() throws {
+    let email = Fixtures.email(
+      subject: "Issue #118",
+      daysAfterEpoch: 100,
+      body: "<p>Hello world</p>"
+    )
+    let source = try Newsletter.Source(
+      email: email,
+      issueNo: 118,
+      slug: "issue-118",
+      featuredImageFallback: Self.fallbackImage
+    )
+    // A passthrough HTML→Markdown closure keeps the assertion offline and stable.
+    let content = try Newsletter.contentBuilder().content(from: source) { $0 }
+
+    #expect(content.hasPrefix("---\n"))
+    #expect(content.contains("issueNo: 118"))
+    #expect(content.contains("buttondownID:"))
+    // `#` starts a YAML comment, so the subject is emitted as a quoted scalar.
+    #expect(content.contains("Issue #118"))
+    #expect(content.contains("longArchiveURL:"))
+    #expect(content.contains("featuredImage:"))
+    // Body follows the closing front-matter delimiter.
+    #expect(content.contains("---\n<p>Hello world</p>"))
+  }
+}


### PR DESCRIPTION
Implements #122 — a new `import buttondown` CLI command that imports newly-published Buttondown newsletters into local markdown. It reads Buttondown and writes ONLY local `Content/newsletters/*.md` (reversible), skipping issues already present locally and generating markdown only for NEW issues (the local archive ends at issue 117, so new = 118+).

## What's new

**New module `Sources/ContributeButtondown/`** — a fresh, non-deprecated analog of the deprecated `ContributeMailchimp.Newsletter`, reusing the `Contribute` pipeline (no deprecated symbols):
- `Newsletter: ContentType` + `Source` (conforms to `HTMLSource`) / `FrontMatter` / `FrontMatterTranslator`. The email `body` HTML → CommonMark via the shared `SwiftSoupMarkdownGenerator`, reusing `FilteredHTMLMarkdownExtractor`.
- `IssueNumbering` — the issue-number strategy (below), pure/testable.
- Front matter mirrors what the site's `NewsletterItem` reads: `issueNo`, `title`, `date`, `description`, `featuredImage` (from `Email.image`, with a site-default fallback so the required `featuredImage` metadata is always present), `longArchiveURL` (from `Email.absoluteURL`); plus `buttondownID` for provenance/reversibility (ignored by the site, like Mailchimp's `campaignID`).

**New `Import.ButtondownCommand` (`import buttondown`)** — reads `--export-markdown-directory` and the Buttondown API key (`--buttondown-api-key` or `BUTTONDOWN_API_KEY`), lists `.sent` emails, assigns issue numbers, skips issues already on disk (matched by the `NNN-` filename prefix), and writes `NNN-slug.md` for new ones only. Registered in `CommandDispatcher`. `ContributeButtondown` target/product and the `ButtondownKit` package dependency were added to `Package.swift`.

## issueNo strategy

Buttondown `Email` has no explicit issueNo. The importer sorts `.sent` emails by `creationDate` ascending and, per email: if the subject contains an explicit "Issue N" / "Issue #N" marker, use it; otherwise assign the next sequential number continuing from the local max (and any higher explicit number seen). Numbers already present locally are skipped. In practice the newly-sent Buttondown issues have no "Issue N" in the subject, so they continue the archive as 118, 119, …

## ButtondownKit read-path fix (required for any live listing)

The live API mixes fractional-second (`2026-06-29T18:36:10.808726Z`) and whole-second (`2026-06-30T12:03:00Z`) timestamps in a single response. OpenAPIRuntime's default ISO8601 transcoder is configured for exactly one shape and threw `DecodingError.dataCorrupted` ("Expected date string to be ISO8601-formatted") on the other, so **every** real `list_emails` decode failed. Added `LenientISO8601DateTranscoder` (tries fractional then whole-second) and installed it on the URLSession client `Configuration`, with unit tests + a mixed-timestamp fixture. This lives in the `ButtondownKit` subrepo (it fixes the merged #124 read path) — flagging for review; a subrepo push is at Leo's discretion.

## Verification

- `swift build` — succeeds; zero new warnings from the new code (pre-existing warnings are the deprecated `ContributeMailchimp` and `ContributeYouTube` usages). Swift 6.4 strict concurrency; language mode not lowered.
- `swift test` — new Swift Testing suites pass: `ContributeButtondownTests` (9 tests: issue parsing/assignment + skip logic, and `Email → Source → FrontMatter` translation incl. full content build) and `ButtondownKit`'s `LenientISO8601DateTranscoderTests` (4 tests).
- **Live dry run** (key sourced from the out-of-repo `brightdigit.com.env`, never committed): generated `118-…md` and `119-…md` with correct front matter and issueNo continuation from 117; issues 1–117 skipped. The two imported files were reverted — this PR contains code only, no imported content.

Base: `phase-05`. Do not merge — Leo reviews and merges.