### PR TITLE
Archive one-shot: updateEmail + buttondown reconcile (#127)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,6 +34,7 @@ let package = Package(
 
     .package(path: "Packages/BrightDigit/SwiftTube"),
     .package(path: "Packages/BrightDigit/Spinetail"),
+    .package(path: "Packages/BrightDigit/ButtondownKit"),
     .package(path: "Packages/BrightDigit/SyndiKit"),
     // .package(url: "https://github.com/BrightDigit/Options.git", from: "0.2.0"),
     .package(path: "Packages/BrightDigit/NPMPublishPlugin"),
@@ -70,6 +71,7 @@ let package = Package(
         "ContributeMailchimp",
         "ContributeWordPress",
         .product(name: "Spinetail", package: "Spinetail"),
+        .product(name: "ButtondownKit", package: "ButtondownKit"),
         .product(name: "ConfigKeyKit", package: "ConfigKeyKit"),
         .product(name: "Configuration", package: "swift-configuration"),
       ]
@@ -123,7 +125,9 @@ let package = Package(
       name: "BrightDigitArgsTests",
       dependencies: [
         "BrightDigitArgs",
-        "BrightDigitPodcast"
+        "BrightDigitPodcast",
+        .product(name: "Spinetail", package: "Spinetail"),
+        .product(name: "ButtondownKit", package: "ButtondownKit")
       ]
     )
   ]

--- a/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/ButtondownClient.swift
+++ b/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/ButtondownClient.swift
@@ -43,8 +43,9 @@ import OpenAPIRuntime
 /// ``ButtondownClient`` wraps the swift-openapi-generator ``Client`` with an
 /// ``AuthenticationMiddleware`` and exposes a small, ergonomic surface via the
 /// capability protocols it conforms to: ``EmailListing`` (list/page emails),
-/// ``EmailDrafting`` (create/send drafts), and ``EmailRetrieving`` (read one
-/// email). Those capabilities implement their methods against ``underlying`` in
+/// ``EmailDrafting`` (create/send drafts), ``EmailRetrieving`` (read one
+/// email), and ``EmailUpdating`` (patch an email). Those capabilities implement
+/// their methods against ``underlying`` in
 /// extensions constrained on ``UnderlyingClientProtocol``, so this type is only
 /// storage plus initializers. All results are Swift-native domain types
 /// (``Email`` et al.), never the generated `Components.Schemas.*`.
@@ -54,7 +55,7 @@ import OpenAPIRuntime
 /// repository; the API key is supplied via the `BUTTONDOWN_API_KEY` environment
 /// variable.
 public struct ButtondownClient: Sendable, UnderlyingClientProtocol,
-  EmailListing, EmailDrafting, EmailRetrieving
+  EmailListing, EmailDrafting, EmailRetrieving, EmailUpdating
 {
   /// Errors surfaced by ``ButtondownClient``.
   public enum ClientError: Error, Equatable {

--- a/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/EmailDrafting.swift
+++ b/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/EmailDrafting.swift
@@ -37,6 +37,18 @@ public protocol EmailDrafting {
   /// - Throws: An error if the request fails or the response is unexpected.
   func createDraft(subject: String, body: String) async throws -> Email
 
+  /// Creates an archived, never-sent email from a Markdown body.
+  ///
+  /// Used to backfill historical newsletter issues into the archive without
+  /// triggering a send: the email is created with ``EmailStatus/imported`` status
+  /// and archival enabled.
+  /// - Parameters:
+  ///   - subject: The email subject line.
+  ///   - body: The Markdown body of the email.
+  /// - Returns: The created ``Email``.
+  /// - Throws: An error if the request fails or the response is unexpected.
+  func createArchived(subject: String, body: String) async throws -> Email
+
   /// Sends a previously-created draft to all subscribers.
   /// - Parameter id: The id of the draft email to send.
   /// - Throws: An error if the request fails or the response is unexpected.
@@ -61,6 +73,38 @@ extension EmailDrafting where Self: UnderlyingClientProtocol {
     let input = Components.Schemas.EmailInput(
       body: body,
       status: .init(value1: .draft),
+      subject: subject
+    )
+    let output = try await underlying.create_email(body: .json(input))
+    switch output {
+    case .created(let created):
+      return try Email(from: created.body.json)
+    default:
+      throw ButtondownClient.ClientError.unexpectedResponse
+    }
+  }
+
+  /// Creates an archived, never-sent email (a backfilled historical issue).
+  ///
+  /// Maps to `POST /emails` with `status: imported` and `archival_mode: enabled`,
+  /// so the issue appears in the public archive but is never delivered to
+  /// subscribers. This is the backfill path for issues that only ever existed on
+  /// Mailchimp. Buttondown is Markdown-native, so `body` is sent as-is with no
+  /// HTML conversion.
+  /// - Parameters:
+  ///   - subject: The email subject line.
+  ///   - body: The Markdown body of the email.
+  /// - Returns: The created ``Email``.
+  /// - Throws: ``ButtondownClient/ClientError/unexpectedResponse`` on a non-201
+  ///   response, or a transport/decoding error.
+  public func createArchived(
+    subject: String,
+    body: String
+  ) async throws -> Email {
+    let input = Components.Schemas.EmailInput(
+      archival_mode: .init(value1: .enabled),
+      body: body,
+      status: .init(value1: .imported),
       subject: subject
     )
     let output = try await underlying.create_email(body: .json(input))

--- a/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/EmailUpdating.swift
+++ b/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/EmailUpdating.swift
@@ -1,0 +1,89 @@
+//
+//  EmailUpdating.swift
+//  ButtondownKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+/// The capability to update (patch) an existing email.
+public protocol EmailUpdating {
+  /// Updates fields on an existing email, leaving unspecified fields unchanged.
+  /// - Parameters:
+  ///   - id: The id of the email to update.
+  ///   - subject: A new subject line, or `nil` to leave it unchanged.
+  ///   - body: A new body (HTML or Markdown), or `nil` to leave it unchanged.
+  ///   - description: A new description, or `nil` to leave it unchanged.
+  ///   - status: A new status, or `nil` to leave it unchanged.
+  /// - Returns: The updated ``Email``.
+  /// - Throws: An error if the request fails or the response is unexpected.
+  func updateEmail(
+    id: String,
+    subject: String?,
+    body: String?,
+    description: String?,
+    status: EmailStatus?
+  ) async throws -> Email
+}
+
+extension EmailUpdating where Self: UnderlyingClientProtocol {
+  /// Updates fields on an existing email. Maps to `PATCH /emails/{id}`.
+  ///
+  /// Only the arguments you supply are sent; every parameter defaults to `nil`,
+  /// which the Buttondown API treats as "leave this field unchanged". This is
+  /// the read-clean-write path used to repair cruft in already-hosted issues.
+  /// - Parameters:
+  ///   - id: The id of the email to update.
+  ///   - subject: A new subject line, or `nil` to leave it unchanged.
+  ///   - body: A new body (HTML or Markdown), or `nil` to leave it unchanged.
+  ///   - description: A new description, or `nil` to leave it unchanged.
+  ///   - status: A new status, or `nil` to leave it unchanged.
+  /// - Returns: The updated ``Email``.
+  /// - Throws: ``ButtondownClient/ClientError/unexpectedResponse`` on a non-200
+  ///   response, or a transport/decoding error.
+  public func updateEmail(
+    id: String,
+    subject: String? = nil,
+    body: String? = nil,
+    description: String? = nil,
+    status: EmailStatus? = nil
+  ) async throws -> Email {
+    let input = Components.Schemas.EmailUpdateInput(
+      body: body,
+      description: description,
+      status: status.map { .init(value1: $0.schema) },
+      subject: subject
+    )
+    let output = try await underlying.update_email(
+      path: .init(id: id),
+      body: .json(input)
+    )
+    switch output {
+    case .ok(let response):
+      return try Email(from: response.body.json)
+    default:
+      throw ButtondownClient.ClientError.unexpectedResponse
+    }
+  }
+}

--- a/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/Generated/Client.swift
+++ b/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/Generated/Client.swift
@@ -804,6 +804,238 @@ public struct Client: APIProtocol {
             }
         )
     }
+    /// Update Email
+    ///
+    /// Update an email's properties
+    ///
+    /// - Remark: HTTP `PATCH /emails/{id}`.
+    /// - Remark: Generated from `#/paths//emails/{id}/patch(update_email)`.
+    public func update_email(_ input: Operations.update_email.Input) async throws -> Operations.update_email.Output {
+        try await client.send(
+            input: input,
+            forOperation: Operations.update_email.id,
+            serializer: { input in
+                let path = try converter.renderedPath(
+                    template: "/emails/{}",
+                    parameters: [
+                        input.path.id
+                    ]
+                )
+                var request: HTTPTypes.HTTPRequest = .init(
+                    soar_path: path,
+                    method: .patch
+                )
+                suppressMutabilityWarning(&request)
+                converter.setAcceptHeader(
+                    in: &request.headerFields,
+                    contentTypes: input.headers.accept
+                )
+                let body: OpenAPIRuntime.HTTPBody?
+                switch input.body {
+                case let .json(value):
+                    body = try converter.setRequiredRequestBodyAsJSON(
+                        value,
+                        headerFields: &request.headerFields,
+                        contentType: "application/json; charset=utf-8"
+                    )
+                }
+                return (request, body)
+            },
+            deserializer: { response, responseBody in
+                switch response.status.code {
+                case 200:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.update_email.Output.Ok.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas.Email.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .ok(.init(body: body))
+                case 400:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.update_email.Output.BadRequest.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas.ErrorMessage.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .badRequest(.init(body: body))
+                case 401:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.update_email.Output.Unauthorized.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas.ErrorMessage.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .unauthorized(.init(body: body))
+                case 403:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.update_email.Output.Forbidden.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas.ErrorMessage.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .forbidden(.init(body: body))
+                case 404:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.update_email.Output.NotFound.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas.ErrorMessage.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .notFound(.init(body: body))
+                case 409:
+                    return .conflict(.init())
+                case 422:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.update_email.Output.UnprocessableContent.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas.ValidationErrorMessage.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .unprocessableContent(.init(body: body))
+                case 429:
+                    let headers: Operations.update_email.Output.TooManyRequests.Headers = .init(
+                        Retry_hyphen_After: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "Retry-After",
+                            as: Swift.Int.self
+                        ),
+                        X_hyphen_RateLimit_hyphen_Limit: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "X-RateLimit-Limit",
+                            as: Swift.Int.self
+                        ),
+                        X_hyphen_RateLimit_hyphen_Remaining: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "X-RateLimit-Remaining",
+                            as: Swift.Int.self
+                        ),
+                        X_hyphen_RateLimit_hyphen_Reset: try converter.getOptionalHeaderFieldAsURI(
+                            in: response.headerFields,
+                            name: "X-RateLimit-Reset",
+                            as: Swift.Int.self
+                        )
+                    )
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.update_email.Output.TooManyRequests.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas.ErrorMessage.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .tooManyRequests(.init(
+                        headers: headers,
+                        body: body
+                    ))
+                default:
+                    return .undocumented(
+                        statusCode: response.status.code,
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
+                    )
+                }
+            }
+        )
+    }
     /// Send Draft
     ///
     /// Send a draft email to specific recipients

--- a/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/Generated/Types.swift
+++ b/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/Generated/Types.swift
@@ -34,6 +34,13 @@ public protocol APIProtocol: Sendable {
     /// - Remark: HTTP `GET /emails/{id}`.
     /// - Remark: Generated from `#/paths//emails/{id}/get(retrieve_email)`.
     func retrieve_email(_ input: Operations.retrieve_email.Input) async throws -> Operations.retrieve_email.Output
+    /// Update Email
+    ///
+    /// Update an email's properties
+    ///
+    /// - Remark: HTTP `PATCH /emails/{id}`.
+    /// - Remark: Generated from `#/paths//emails/{id}/patch(update_email)`.
+    func update_email(_ input: Operations.update_email.Input) async throws -> Operations.update_email.Output
     /// Send Draft
     ///
     /// Send a draft email to specific recipients
@@ -102,6 +109,23 @@ extension APIProtocol {
         try await retrieve_email(Operations.retrieve_email.Input(
             path: path,
             headers: headers
+        ))
+    }
+    /// Update Email
+    ///
+    /// Update an email's properties
+    ///
+    /// - Remark: HTTP `PATCH /emails/{id}`.
+    /// - Remark: Generated from `#/paths//emails/{id}/patch(update_email)`.
+    public func update_email(
+        path: Operations.update_email.Input.Path,
+        headers: Operations.update_email.Input.Headers = .init(),
+        body: Operations.update_email.Input.Body
+    ) async throws -> Operations.update_email.Output {
+        try await update_email(Operations.update_email.Input(
+            path: path,
+            headers: headers,
+            body: body
         ))
     }
     /// Send Draft
@@ -1275,6 +1299,107 @@ public enum Components {
             case free = "free"
             case churned = "churned"
             case archival = "archival"
+        }
+        /// - Remark: Generated from `#/components/schemas/EmailUpdateInput`.
+        public struct EmailUpdateInput: Codable, Hashable, Sendable {
+            /// The body of the email, in either HTML or markdown format. Buttondown attempts to intelligently detect the format of the body automatically, but you can also specify the format explicitly by prepending the text with the `buttondown-editor-mode` comment: `<!-- buttondown-editor-mode: fancy -->` or `<!-- buttondown-editor-mode: plaintext -->`.
+            ///
+            /// - Remark: Generated from `#/components/schemas/EmailUpdateInput/body`.
+            public var body: Swift.String?
+            /// A human-readable description of the email, used for archives and SEO.
+            ///
+            /// - Remark: Generated from `#/components/schemas/EmailUpdateInput/description`.
+            public var description: Swift.String?
+            /// A primary image URL used when previewing the email on the web or in other contexts.
+            ///
+            /// - Remark: Generated from `#/components/schemas/EmailUpdateInput/image`.
+            public var image: Swift.String?
+            /// The status of the email (e.g. `draft`, `about_to_send`, `sent`, `scheduled`).
+            ///
+            /// - Remark: Generated from `#/components/schemas/EmailUpdateInput/status`.
+            public struct statusPayload: Codable, Hashable, Sendable {
+                /// - Remark: Generated from `#/components/schemas/EmailUpdateInput/status/value1`.
+                public var value1: Components.Schemas.EmailStatus
+                /// Creates a new `statusPayload`.
+                ///
+                /// - Parameters:
+                ///   - value1:
+                public init(value1: Components.Schemas.EmailStatus) {
+                    self.value1 = value1
+                }
+                public init(from decoder: any Swift.Decoder) throws {
+                    self.value1 = try decoder.decodeFromSingleValueContainer()
+                }
+                public func encode(to encoder: any Swift.Encoder) throws {
+                    try encoder.encodeToSingleValueContainer(self.value1)
+                }
+            }
+            /// The status of the email (e.g. `draft`, `about_to_send`, `sent`, `scheduled`).
+            ///
+            /// - Remark: Generated from `#/components/schemas/EmailUpdateInput/status`.
+            public var status: Components.Schemas.EmailUpdateInput.statusPayload?
+            /// The subject line for the email.
+            ///
+            /// - Remark: Generated from `#/components/schemas/EmailUpdateInput/subject`.
+            public var subject: Swift.String?
+            /// Creates a new `EmailUpdateInput`.
+            ///
+            /// - Parameters:
+            ///   - body: The body of the email, in either HTML or markdown format. Buttondown attempts to intelligently detect the format of the body automatically, but you can also specify the format explicitly by prepending the text with the `buttondown-editor-mode` comment: `<!-- buttondown-editor-mode: fancy -->` or `<!-- buttondown-editor-mode: plaintext -->`.
+            ///   - description: A human-readable description of the email, used for archives and SEO.
+            ///   - image: A primary image URL used when previewing the email on the web or in other contexts.
+            ///   - status: The status of the email (e.g. `draft`, `about_to_send`, `sent`, `scheduled`).
+            ///   - subject: The subject line for the email.
+            public init(
+                body: Swift.String? = nil,
+                description: Swift.String? = nil,
+                image: Swift.String? = nil,
+                status: Components.Schemas.EmailUpdateInput.statusPayload? = nil,
+                subject: Swift.String? = nil
+            ) {
+                self.body = body
+                self.description = description
+                self.image = image
+                self.status = status
+                self.subject = subject
+            }
+            public enum CodingKeys: String, CodingKey {
+                case body
+                case description
+                case image
+                case status
+                case subject
+            }
+            public init(from decoder: any Swift.Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                self.body = try container.decodeIfPresent(
+                    Swift.String.self,
+                    forKey: .body
+                )
+                self.description = try container.decodeIfPresent(
+                    Swift.String.self,
+                    forKey: .description
+                )
+                self.image = try container.decodeIfPresent(
+                    Swift.String.self,
+                    forKey: .image
+                )
+                self.status = try container.decodeIfPresent(
+                    Components.Schemas.EmailUpdateInput.statusPayload.self,
+                    forKey: .status
+                )
+                self.subject = try container.decodeIfPresent(
+                    Swift.String.self,
+                    forKey: .subject
+                )
+                try decoder.ensureNoAdditionalProperties(knownKeys: [
+                    "body",
+                    "description",
+                    "image",
+                    "status",
+                    "subject"
+                ])
+            }
         }
         /// - Remark: Generated from `#/components/schemas/ErrorMessage`.
         public struct ErrorMessage: Codable, Hashable, Sendable {
@@ -3963,6 +4088,530 @@ public enum Operations {
             /// - Throws: An error if `self` is not `.tooManyRequests`.
             /// - SeeAlso: `.tooManyRequests`.
             public var tooManyRequests: Operations.retrieve_email.Output.TooManyRequests {
+                get throws {
+                    switch self {
+                    case let .tooManyRequests(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "tooManyRequests",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        @frozen public enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            public init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            public var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            public static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
+    /// Update Email
+    ///
+    /// Update an email's properties
+    ///
+    /// - Remark: HTTP `PATCH /emails/{id}`.
+    /// - Remark: Generated from `#/paths//emails/{id}/patch(update_email)`.
+    public enum update_email {
+        public static let id: Swift.String = "update_email"
+        public struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/emails/{id}/PATCH/path`.
+            public struct Path: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/emails/{id}/PATCH/path/id`.
+                public var id: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - id:
+                public init(id: Swift.String) {
+                    self.id = id
+                }
+            }
+            public var path: Operations.update_email.Input.Path
+            /// - Remark: Generated from `#/paths/emails/{id}/PATCH/header`.
+            public struct Headers: Sendable, Hashable {
+                public var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.update_email.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                public init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.update_email.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            public var headers: Operations.update_email.Input.Headers
+            /// - Remark: Generated from `#/paths/emails/{id}/PATCH/requestBody`.
+            @frozen public enum Body: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/emails/{id}/PATCH/requestBody/content/application\/json`.
+                case json(Components.Schemas.EmailUpdateInput)
+            }
+            public var body: Operations.update_email.Input.Body
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - headers:
+            ///   - body:
+            public init(
+                path: Operations.update_email.Input.Path,
+                headers: Operations.update_email.Input.Headers = .init(),
+                body: Operations.update_email.Input.Body
+            ) {
+                self.path = path
+                self.headers = headers
+                self.body = body
+            }
+        }
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Ok: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/emails/{id}/PATCH/responses/200/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/emails/{id}/PATCH/responses/200/content/application\/json`.
+                    case json(Components.Schemas.Email)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas.Email {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.update_email.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.update_email.Output.Ok.Body) {
+                    self.body = body
+                }
+            }
+            /// OK
+            ///
+            /// - Remark: Generated from `#/paths//emails/{id}/patch(update_email)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.update_email.Output.Ok)
+            /// The associated value of the enum case if `self` is `.ok`.
+            ///
+            /// - Throws: An error if `self` is not `.ok`.
+            /// - SeeAlso: `.ok`.
+            public var ok: Operations.update_email.Output.Ok {
+                get throws {
+                    switch self {
+                    case let .ok(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "ok",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct BadRequest: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/emails/{id}/PATCH/responses/400/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/emails/{id}/PATCH/responses/400/content/application\/json`.
+                    case json(Components.Schemas.ErrorMessage)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas.ErrorMessage {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.update_email.Output.BadRequest.Body
+                /// Creates a new `BadRequest`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.update_email.Output.BadRequest.Body) {
+                    self.body = body
+                }
+            }
+            /// Bad Request
+            ///
+            /// - Remark: Generated from `#/paths//emails/{id}/patch(update_email)/responses/400`.
+            ///
+            /// HTTP response code: `400 badRequest`.
+            case badRequest(Operations.update_email.Output.BadRequest)
+            /// The associated value of the enum case if `self` is `.badRequest`.
+            ///
+            /// - Throws: An error if `self` is not `.badRequest`.
+            /// - SeeAlso: `.badRequest`.
+            public var badRequest: Operations.update_email.Output.BadRequest {
+                get throws {
+                    switch self {
+                    case let .badRequest(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "badRequest",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Unauthorized: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/emails/{id}/PATCH/responses/401/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/emails/{id}/PATCH/responses/401/content/application\/json`.
+                    case json(Components.Schemas.ErrorMessage)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas.ErrorMessage {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.update_email.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.update_email.Output.Unauthorized.Body) {
+                    self.body = body
+                }
+            }
+            /// Unauthorized
+            ///
+            /// - Remark: Generated from `#/paths//emails/{id}/patch(update_email)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.update_email.Output.Unauthorized)
+            /// The associated value of the enum case if `self` is `.unauthorized`.
+            ///
+            /// - Throws: An error if `self` is not `.unauthorized`.
+            /// - SeeAlso: `.unauthorized`.
+            public var unauthorized: Operations.update_email.Output.Unauthorized {
+                get throws {
+                    switch self {
+                    case let .unauthorized(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "unauthorized",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Forbidden: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/emails/{id}/PATCH/responses/403/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/emails/{id}/PATCH/responses/403/content/application\/json`.
+                    case json(Components.Schemas.ErrorMessage)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas.ErrorMessage {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.update_email.Output.Forbidden.Body
+                /// Creates a new `Forbidden`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.update_email.Output.Forbidden.Body) {
+                    self.body = body
+                }
+            }
+            /// Forbidden
+            ///
+            /// - Remark: Generated from `#/paths//emails/{id}/patch(update_email)/responses/403`.
+            ///
+            /// HTTP response code: `403 forbidden`.
+            case forbidden(Operations.update_email.Output.Forbidden)
+            /// The associated value of the enum case if `self` is `.forbidden`.
+            ///
+            /// - Throws: An error if `self` is not `.forbidden`.
+            /// - SeeAlso: `.forbidden`.
+            public var forbidden: Operations.update_email.Output.Forbidden {
+                get throws {
+                    switch self {
+                    case let .forbidden(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "forbidden",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct NotFound: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/emails/{id}/PATCH/responses/404/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/emails/{id}/PATCH/responses/404/content/application\/json`.
+                    case json(Components.Schemas.ErrorMessage)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas.ErrorMessage {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.update_email.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.update_email.Output.NotFound.Body) {
+                    self.body = body
+                }
+            }
+            /// Not Found
+            ///
+            /// - Remark: Generated from `#/paths//emails/{id}/patch(update_email)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.update_email.Output.NotFound)
+            /// The associated value of the enum case if `self` is `.notFound`.
+            ///
+            /// - Throws: An error if `self` is not `.notFound`.
+            /// - SeeAlso: `.notFound`.
+            public var notFound: Operations.update_email.Output.NotFound {
+                get throws {
+                    switch self {
+                    case let .notFound(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "notFound",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Conflict: Sendable, Hashable {
+                /// Creates a new `Conflict`.
+                public init() {}
+            }
+            /// Conflict
+            ///
+            /// - Remark: Generated from `#/paths//emails/{id}/patch(update_email)/responses/409`.
+            ///
+            /// HTTP response code: `409 conflict`.
+            case conflict(Operations.update_email.Output.Conflict)
+            /// Conflict
+            ///
+            /// - Remark: Generated from `#/paths//emails/{id}/patch(update_email)/responses/409`.
+            ///
+            /// HTTP response code: `409 conflict`.
+            public static var conflict: Self {
+                .conflict(.init())
+            }
+            /// The associated value of the enum case if `self` is `.conflict`.
+            ///
+            /// - Throws: An error if `self` is not `.conflict`.
+            /// - SeeAlso: `.conflict`.
+            public var conflict: Operations.update_email.Output.Conflict {
+                get throws {
+                    switch self {
+                    case let .conflict(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "conflict",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct UnprocessableContent: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/emails/{id}/PATCH/responses/422/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/emails/{id}/PATCH/responses/422/content/application\/json`.
+                    case json(Components.Schemas.ValidationErrorMessage)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas.ValidationErrorMessage {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.update_email.Output.UnprocessableContent.Body
+                /// Creates a new `UnprocessableContent`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.update_email.Output.UnprocessableContent.Body) {
+                    self.body = body
+                }
+            }
+            /// Unprocessable Entity
+            ///
+            /// - Remark: Generated from `#/paths//emails/{id}/patch(update_email)/responses/422`.
+            ///
+            /// HTTP response code: `422 unprocessableContent`.
+            case unprocessableContent(Operations.update_email.Output.UnprocessableContent)
+            /// The associated value of the enum case if `self` is `.unprocessableContent`.
+            ///
+            /// - Throws: An error if `self` is not `.unprocessableContent`.
+            /// - SeeAlso: `.unprocessableContent`.
+            public var unprocessableContent: Operations.update_email.Output.UnprocessableContent {
+                get throws {
+                    switch self {
+                    case let .unprocessableContent(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "unprocessableContent",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct TooManyRequests: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/emails/{id}/PATCH/responses/429/headers`.
+                public struct Headers: Sendable, Hashable {
+                    /// Seconds to wait before retrying.
+                    ///
+                    /// - Remark: Generated from `#/paths/emails/{id}/PATCH/responses/429/headers/Retry-After`.
+                    public var Retry_hyphen_After: Swift.Int?
+                    /// Requests permitted per minute.
+                    ///
+                    /// - Remark: Generated from `#/paths/emails/{id}/PATCH/responses/429/headers/X-RateLimit-Limit`.
+                    public var X_hyphen_RateLimit_hyphen_Limit: Swift.Int?
+                    /// Requests remaining in the current window.
+                    ///
+                    /// - Remark: Generated from `#/paths/emails/{id}/PATCH/responses/429/headers/X-RateLimit-Remaining`.
+                    public var X_hyphen_RateLimit_hyphen_Remaining: Swift.Int?
+                    /// Unix timestamp at which the window resets.
+                    ///
+                    /// - Remark: Generated from `#/paths/emails/{id}/PATCH/responses/429/headers/X-RateLimit-Reset`.
+                    public var X_hyphen_RateLimit_hyphen_Reset: Swift.Int?
+                    /// Creates a new `Headers`.
+                    ///
+                    /// - Parameters:
+                    ///   - Retry_hyphen_After: Seconds to wait before retrying.
+                    ///   - X_hyphen_RateLimit_hyphen_Limit: Requests permitted per minute.
+                    ///   - X_hyphen_RateLimit_hyphen_Remaining: Requests remaining in the current window.
+                    ///   - X_hyphen_RateLimit_hyphen_Reset: Unix timestamp at which the window resets.
+                    public init(
+                        Retry_hyphen_After: Swift.Int? = nil,
+                        X_hyphen_RateLimit_hyphen_Limit: Swift.Int? = nil,
+                        X_hyphen_RateLimit_hyphen_Remaining: Swift.Int? = nil,
+                        X_hyphen_RateLimit_hyphen_Reset: Swift.Int? = nil
+                    ) {
+                        self.Retry_hyphen_After = Retry_hyphen_After
+                        self.X_hyphen_RateLimit_hyphen_Limit = X_hyphen_RateLimit_hyphen_Limit
+                        self.X_hyphen_RateLimit_hyphen_Remaining = X_hyphen_RateLimit_hyphen_Remaining
+                        self.X_hyphen_RateLimit_hyphen_Reset = X_hyphen_RateLimit_hyphen_Reset
+                    }
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.update_email.Output.TooManyRequests.Headers
+                /// - Remark: Generated from `#/paths/emails/{id}/PATCH/responses/429/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/emails/{id}/PATCH/responses/429/content/application\/json`.
+                    case json(Components.Schemas.ErrorMessage)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas.ErrorMessage {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.update_email.Output.TooManyRequests.Body
+                /// Creates a new `TooManyRequests`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.update_email.Output.TooManyRequests.Headers = .init(),
+                    body: Operations.update_email.Output.TooManyRequests.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// Too Many Requests
+            ///
+            /// - Remark: Generated from `#/paths//emails/{id}/patch(update_email)/responses/429`.
+            ///
+            /// HTTP response code: `429 tooManyRequests`.
+            case tooManyRequests(Operations.update_email.Output.TooManyRequests)
+            /// The associated value of the enum case if `self` is `.tooManyRequests`.
+            ///
+            /// - Throws: An error if `self` is not `.tooManyRequests`.
+            /// - SeeAlso: `.tooManyRequests`.
+            public var tooManyRequests: Operations.update_email.Output.TooManyRequests {
                 get throws {
                     switch self {
                     case let .tooManyRequests(response):

--- a/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/OpenAPI/openapi-generator-config.yaml
+++ b/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/OpenAPI/openapi-generator-config.yaml
@@ -22,6 +22,7 @@ additionalFileComments:
 filter:
   operations:
     - create_email      # POST /emails               — create a draft
+    - update_email      # PATCH /emails/{id}         — update an existing email
     - send_draft        # POST /emails/{id}/send-draft — send the draft
     - list_emails       # GET  /emails               — read (round-trip tests)
     - retrieve_email    # GET  /emails/{id}          — read (round-trip tests)

--- a/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/OpenAPI/openapi.json
+++ b/Packages/BrightDigit/ButtondownKit/Sources/ButtondownKit/OpenAPI/openapi.json
@@ -3562,17 +3562,10 @@
             "title": "Attachments"
           },
           "body": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
             "description": "The body of the email, in either HTML or markdown format. Buttondown attempts to intelligently detect the format of the body automatically, but you can also specify the format explicitly by prepending the text with the `buttondown-editor-mode` comment: `<!-- buttondown-editor-mode: fancy -->` or `<!-- buttondown-editor-mode: plaintext -->`.",
             "example": "This is an example of the body of an email.",
-            "title": "Body"
+            "title": "Body",
+            "type": "string"
           },
           "canonical_url": {
             "anyOf": [
@@ -3600,16 +3593,9 @@
             "description": "Controls whether subscribers can comment on this email."
           },
           "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
             "description": "A human-readable description of the email, used for archives and SEO.",
-            "title": "Description"
+            "title": "Description",
+            "type": "string"
           },
           "email_type": {
             "anyOf": [
@@ -3744,29 +3730,19 @@
             "title": "Slug"
           },
           "status": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/EmailStatus"
-              },
-              {
-                "type": "null"
               }
             ],
             "description": "The status of the email (e.g. `draft`, `about_to_send`, `sent`, `scheduled`)."
           },
           "subject": {
-            "anyOf": [
-              {
-                "maxLength": 2000,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
             "description": "The subject line for the email.",
             "example": "The subject line for the email",
-            "title": "Subject"
+            "maxLength": 2000,
+            "title": "Subject",
+            "type": "string"
           },
           "suppression_reason": {
             "anyOf": [

--- a/Packages/BrightDigit/ButtondownKit/Tests/ButtondownKitTests/EmailArchivingTests.swift
+++ b/Packages/BrightDigit/ButtondownKit/Tests/ButtondownKitTests/EmailArchivingTests.swift
@@ -1,0 +1,119 @@
+//
+//  EmailArchivingTests.swift
+//  ButtondownKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import Foundation
+import HTTPTypes
+import OpenAPIRuntime
+import Testing
+
+@testable import ButtondownKit
+
+@Suite internal struct EmailArchivingTests {
+  private static let apiKey = "FAKE_KEY"
+  private static let emailID = "00000000-0000-0000-0000-000000000001"
+
+  /// Loads a JSON fixture from the test bundle's copied `Fixtures` directory.
+  private func fixture(_ name: String) throws -> String {
+    let url = try #require(
+      Bundle.module.url(
+        forResource: name,
+        withExtension: "json",
+        subdirectory: "Fixtures"
+      ),
+      "missing fixture \(name).json"
+    )
+    return try String(contentsOf: url, encoding: .utf8)
+  }
+
+  /// Builds a `ButtondownClient` over the supplied mock transport, with the
+  /// real authentication middleware in place so its behaviour is exercised.
+  private func makeClient(_ transport: MockTransport) throws -> ButtondownClient {
+    let generated = Client(
+      serverURL: try Servers.Server1.url(),
+      transport: transport,
+      middlewares: [AuthenticationMiddleware(apiKey: Self.apiKey)]
+    )
+    return ButtondownClient(underlying: generated)
+  }
+
+  /// `createArchived` POSTs an `imported`/archival-enabled email and decodes the
+  /// 201 `Email` back — the historical-issue backfill round trip.
+  @Test internal func createArchivedRoundTrip() async throws {
+    let transport = MockTransport(responses: [
+      "POST /emails": [.init(status: 201, json: try fixture("email-archived"))]
+    ])
+    let client = try makeClient(transport)
+
+    let email = try await client.createArchived(
+      subject: "BrightDigit #42",
+      body: "# Heading\n\nThis is a backfilled archive issue body."
+    )
+
+    #expect(email.id == Self.emailID)
+    #expect(email.status == .imported)
+    #expect(email.body.contains("backfilled archive issue body"))
+
+    let recorded = await transport.recorded
+    let request = try #require(recorded.first)
+    #expect(request.method == "POST")
+    #expect(request.path == "/emails")
+    let body = try #require(request.body)
+    #expect(body.contains("imported"), "the email should be created with imported status")
+    #expect(body.contains("enabled"), "archival_mode should serialize as enabled")
+    #expect(body.contains("backfilled archive issue body"), "the body should be sent")
+  }
+
+  /// The authentication middleware attaches `Authorization: Token <key>`.
+  @Test internal func createArchivedAttachesAuthorization() async throws {
+    let transport = MockTransport(responses: [
+      "POST /emails": [.init(status: 201, json: try fixture("email-archived"))]
+    ])
+    let client = try makeClient(transport)
+
+    _ = try await client.createArchived(subject: "s", body: "b")
+
+    let recorded = await transport.recorded
+    let request = try #require(recorded.first)
+    #expect(request.headerFields[.authorization] == "Token \(Self.apiKey)")
+  }
+
+  /// A documented error status (403) surfaces as `unexpectedResponse`.
+  @Test internal func createArchivedUnexpectedStatusThrows() async throws {
+    let transport = MockTransport(responses: [
+      "POST /emails": [
+        .init(status: 403, json: #"{"detail":"nope","code":"forbidden"}"#)
+      ]
+    ])
+    let client = try makeClient(transport)
+
+    await #expect(throws: ButtondownClient.ClientError.unexpectedResponse) {
+      _ = try await client.createArchived(subject: "s", body: "b")
+    }
+  }
+}

--- a/Packages/BrightDigit/ButtondownKit/Tests/ButtondownKitTests/EmailUpdatingTests.swift
+++ b/Packages/BrightDigit/ButtondownKit/Tests/ButtondownKitTests/EmailUpdatingTests.swift
@@ -1,0 +1,121 @@
+//
+//  EmailUpdatingTests.swift
+//  ButtondownKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import Foundation
+import HTTPTypes
+import OpenAPIRuntime
+import Testing
+
+@testable import ButtondownKit
+
+@Suite internal struct EmailUpdatingTests {
+  private static let apiKey = "FAKE_KEY"
+  private static let emailID = "00000000-0000-0000-0000-000000000001"
+
+  /// Loads a JSON fixture from the test bundle's copied `Fixtures` directory.
+  private func fixture(_ name: String) throws -> String {
+    let url = try #require(
+      Bundle.module.url(
+        forResource: name,
+        withExtension: "json",
+        subdirectory: "Fixtures"
+      ),
+      "missing fixture \(name).json"
+    )
+    return try String(contentsOf: url, encoding: .utf8)
+  }
+
+  /// Builds a `ButtondownClient` over the supplied mock transport, with the
+  /// real authentication middleware in place so its behaviour is exercised.
+  private func makeClient(_ transport: MockTransport) throws -> ButtondownClient {
+    let generated = Client(
+      serverURL: try Servers.Server1.url(),
+      transport: transport,
+      middlewares: [AuthenticationMiddleware(apiKey: Self.apiKey)]
+    )
+    return ButtondownClient(underlying: generated)
+  }
+
+  /// `updateEmail` PATCHes `/emails/{id}` with only the supplied fields and
+  /// decodes the 200 `Email` back — the read-clean-write round trip.
+  @Test internal func updateEmailRoundTrip() async throws {
+    let transport = MockTransport(responses: [
+      "PATCH /emails/\(Self.emailID)": [.init(status: 200, json: try fixture("email-updated"))]
+    ])
+    let client = try makeClient(transport)
+
+    let email = try await client.updateEmail(
+      id: Self.emailID,
+      body: "# Heading\n\nThis is the cleaned newsletter body.",
+      status: .imported
+    )
+
+    #expect(email.id == Self.emailID)
+    #expect(email.status == .imported)
+    #expect(email.body.contains("cleaned newsletter body"))
+
+    let recorded = await transport.recorded
+    let request = try #require(recorded.first)
+    #expect(request.method == "PATCH")
+    #expect(request.path == "/emails/\(Self.emailID)")
+    let body = try #require(request.body)
+    #expect(body.contains("cleaned newsletter body"), "the new body should be sent")
+    #expect(body.contains("imported"), "status should serialize as imported")
+    // Unspecified fields are omitted from the PATCH payload.
+    #expect(!body.contains("\"subject\""), "subject was not supplied, so it should be omitted")
+  }
+
+  /// The authentication middleware attaches `Authorization: Token <key>`.
+  @Test internal func updateEmailAttachesAuthorization() async throws {
+    let transport = MockTransport(responses: [
+      "PATCH /emails/\(Self.emailID)": [.init(status: 200, json: try fixture("email-updated"))]
+    ])
+    let client = try makeClient(transport)
+
+    _ = try await client.updateEmail(id: Self.emailID, body: "b")
+
+    let recorded = await transport.recorded
+    let request = try #require(recorded.first)
+    #expect(request.headerFields[.authorization] == "Token \(Self.apiKey)")
+  }
+
+  /// A documented error status (403) surfaces as `unexpectedResponse`.
+  @Test internal func updateEmailUnexpectedStatusThrows() async throws {
+    let transport = MockTransport(responses: [
+      "PATCH /emails/\(Self.emailID)": [
+        .init(status: 403, json: #"{"detail":"nope","code":"forbidden"}"#)
+      ]
+    ])
+    let client = try makeClient(transport)
+
+    await #expect(throws: ButtondownClient.ClientError.unexpectedResponse) {
+      _ = try await client.updateEmail(id: Self.emailID, body: "b")
+    }
+  }
+}

--- a/Packages/BrightDigit/ButtondownKit/Tests/ButtondownKitTests/Fixtures/email-archived.json
+++ b/Packages/BrightDigit/ButtondownKit/Tests/ButtondownKitTests/Fixtures/email-archived.json
@@ -1,0 +1,23 @@
+{
+  "id": "00000000-0000-0000-0000-000000000001",
+  "subject": "BrightDigit #42",
+  "body": "# Heading\n\nThis is a backfilled archive issue body.",
+  "status": "imported",
+  "source": "api",
+  "commenting_mode": "enabled",
+  "archival_mode": "enabled",
+  "absolute_url": "https://buttondown.com/example/archive/brightdigit-42/",
+  "canonical_url": "",
+  "image": "",
+  "description": "",
+  "featured": false,
+  "should_trigger_pay_per_email_billing": false,
+  "related_email_ids": [],
+  "creation_date": "2026-06-17T12:00:00Z",
+  "modification_date": "2026-06-17T12:00:00Z",
+  "filters": {
+    "predicate": "and",
+    "filters": [],
+    "groups": []
+  }
+}

--- a/Packages/BrightDigit/ButtondownKit/Tests/ButtondownKitTests/Fixtures/email-updated.json
+++ b/Packages/BrightDigit/ButtondownKit/Tests/ButtondownKitTests/Fixtures/email-updated.json
@@ -1,0 +1,23 @@
+{
+  "id": "00000000-0000-0000-0000-000000000001",
+  "subject": "Hello from ButtondownKit",
+  "body": "# Heading\n\nThis is the cleaned newsletter body.",
+  "status": "imported",
+  "source": "api",
+  "commenting_mode": "enabled",
+  "archival_mode": "enabled",
+  "absolute_url": "https://buttondown.com/example/archive/hello-from-buttondownkit/",
+  "canonical_url": "",
+  "image": "",
+  "description": "",
+  "featured": false,
+  "should_trigger_pay_per_email_billing": false,
+  "related_email_ids": [],
+  "creation_date": "2026-06-17T12:00:00Z",
+  "modification_date": "2026-06-18T09:30:00Z",
+  "filters": {
+    "predicate": "and",
+    "filters": [],
+    "groups": []
+  }
+}

--- a/Sources/BrightDigitArgs/Config/Buttondown.ReconcileCommand+Plan.swift
+++ b/Sources/BrightDigitArgs/Config/Buttondown.ReconcileCommand+Plan.swift
@@ -1,0 +1,197 @@
+//
+//  Buttondown.ReconcileCommand+Plan.swift
+//  BrightDigit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import ButtondownKit
+import Foundation
+import Spinetail
+
+extension Buttondown.ReconcileCommand {
+  /// The kind of Buttondown write a reconcile plan item represents.
+  internal enum Action: String, Equatable, Sendable {
+    /// Backfill: the issue is absent from Buttondown, so create it as an
+    /// archived / never-sent email.
+    case create
+    /// Clean: the issue already exists in Buttondown, so patch its body.
+    case update
+  }
+
+  /// A Mailchimp campaign assigned its canonical BrightDigit issue number.
+  internal struct NumberedCampaign: Equatable, Sendable {
+    internal let issueNo: Int
+    internal let campaignID: String
+    internal let subject: String
+    internal let sendTime: Date
+  }
+
+  /// A single reconcile action for one newsletter issue.
+  internal struct PlanItem: Equatable, Sendable {
+    internal let issueNo: Int
+    internal let subject: String
+    internal let campaignID: String
+    internal let action: Action
+    /// The existing Buttondown email id (UPDATE only); `nil` for CREATE.
+    internal let existingEmailID: String?
+  }
+
+  /// Whether a campaign is a BrightDigit newsletter, by segment or subject line.
+  ///
+  /// Mirrors `Import.MailchimpCommand.isBrightDigitNewsletter` (which is private);
+  /// kept identical so reconcile and import agree on which campaigns count.
+  private static func isBrightDigitNewsletter(
+    campaign: MailchimpCampaign,
+    subjectLine: String
+  ) -> Bool {
+    let brightdigitSent =
+      campaign.segmentText?.contains("brightdigit-business") == true
+    return brightdigitSent || subjectLine.contains("BrightDigit Newsletter")
+  }
+
+  /// Assigns each BrightDigit newsletter campaign its canonical issue number.
+  ///
+  /// Mirrors `Import.MailchimpCommand.selectCampaigns` and reuses its
+  /// ``Import/MailchimpCommand/parseIssueNumber(from:)``: keep BrightDigit
+  /// newsletters that have a send time, sort oldest-first, assign the number
+  /// parsed from the subject line, number trailing *unnumbered* campaigns
+  /// sequentially after the last explicitly-numbered issue, and skip interior
+  /// unnumbered broadcasts (one-off blasts, not numbered newsletters).
+  /// - Parameter campaigns: Every sent campaign returned by Mailchimp.
+  /// - Returns: The numbered newsletters, in send-time (oldest-first) order.
+  internal static func numberedCampaigns(
+    from campaigns: [MailchimpCampaign]
+  ) -> [NumberedCampaign] {
+    let newsletters =
+      campaigns
+      .compactMap { campaign -> (campaign: MailchimpCampaign, sendTime: Date)? in
+        let subjectLine = campaign.subjectLine ?? ""
+        guard
+          isBrightDigitNewsletter(campaign: campaign, subjectLine: subjectLine),
+          let sendTime = campaign.sendTime
+        else {
+          return nil
+        }
+        return (campaign, sendTime)
+      }
+      .sorted { $0.sendTime < $1.sendTime }
+
+    let numbered =
+      newsletters
+      .filter {
+        Import.MailchimpCommand.parseIssueNumber(from: $0.campaign.subjectLine ?? "")
+          != nil
+      }
+    let maxExplicit =
+      numbered
+      .compactMap {
+        Import.MailchimpCommand.parseIssueNumber(from: $0.campaign.subjectLine ?? "")
+      }
+      .max() ?? 0
+    let lastNumberedDate = numbered.map(\.sendTime).max()
+
+    var result: [NumberedCampaign] = []
+    var trailingIssueNo = maxExplicit
+    for (campaign, sendTime) in newsletters {
+      let subjectLine = campaign.subjectLine ?? ""
+      let issueNo: Int
+      if let explicit = Import.MailchimpCommand.parseIssueNumber(from: subjectLine) {
+        issueNo = explicit
+      } else if let lastDate = lastNumberedDate, sendTime > lastDate {
+        trailingIssueNo += 1
+        issueNo = trailingIssueNo
+      } else {
+        continue
+      }
+      guard let campaignID = campaign.id else {
+        continue
+      }
+      result.append(
+        NumberedCampaign(
+          issueNo: issueNo,
+          campaignID: campaignID,
+          subject: subjectLine,
+          sendTime: sendTime
+        )
+      )
+    }
+    return result
+  }
+
+  /// Indexes Buttondown emails by the issue number parsed from their subject.
+  ///
+  /// Emails whose subject carries no BrightDigit issue number are ignored. When
+  /// two emails share a number (shouldn't normally happen) the first wins.
+  /// - Parameter emails: The current Buttondown emails.
+  /// - Returns: A map from issue number to the corresponding email.
+  internal static func emailsByIssueNo(_ emails: [Email]) -> [Int: Email] {
+    var map: [Int: Email] = [:]
+    for email in emails {
+      guard
+        let issueNo = Import.MailchimpCommand.parseIssueNumber(from: email.subject),
+        map[issueNo] == nil
+      else {
+        continue
+      }
+      map[issueNo] = email
+    }
+    return map
+  }
+
+  /// Classifies each numbered campaign as CREATE (absent from Buttondown) or
+  /// UPDATE (already present), the pure heart of the reconciliation.
+  ///
+  /// - Parameters:
+  ///   - numbered: The Mailchimp campaigns with issue numbers assigned.
+  ///   - buttondownByIssueNo: The current Buttondown emails indexed by issue
+  ///     number (see ``emailsByIssueNo(_:)``).
+  /// - Returns: One ``PlanItem`` per campaign, sorted by issue number ascending.
+  internal static func buildPlan(
+    numbered: [NumberedCampaign],
+    buttondownByIssueNo: [Int: Email]
+  ) -> [PlanItem] {
+    numbered
+      .sorted { $0.issueNo < $1.issueNo }
+      .map { campaign in
+        if let existing = buttondownByIssueNo[campaign.issueNo] {
+          return PlanItem(
+            issueNo: campaign.issueNo,
+            subject: campaign.subject,
+            campaignID: campaign.campaignID,
+            action: .update,
+            existingEmailID: existing.id
+          )
+        }
+        return PlanItem(
+          issueNo: campaign.issueNo,
+          subject: campaign.subject,
+          campaignID: campaign.campaignID,
+          action: .create,
+          existingEmailID: nil
+        )
+      }
+  }
+}

--- a/Sources/BrightDigitArgs/Config/Buttondown.ReconcileCommand.swift
+++ b/Sources/BrightDigitArgs/Config/Buttondown.ReconcileCommand.swift
@@ -1,0 +1,262 @@
+//
+//  Buttondown.ReconcileCommand.swift
+//  BrightDigit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import ButtondownKit
+import ConfigKeyKit
+import Configuration
+import Contribute
+import Foundation
+import Spinetail
+
+extension Buttondown.ReconcileCommand {
+  /// Resolved configuration for the `buttondown reconcile` command.
+  public struct Config: ConfigurationParseable {
+    public typealias ConfigReader = Configuration.ConfigReader
+    public typealias BaseConfig = Never
+
+    internal let mailchimpAPIKey: String
+    internal let mailchimpListID: String
+    internal let buttondownAPIKey: String?
+    internal let execute: Bool
+
+    public init(
+      configuration reader: Configuration.ConfigReader,
+      base _: Never?
+    ) async throws {
+      guard let mailchimpAPIKey = reader.read(Keys.mailchimpAPIKey) else {
+        throw CommandError.missingRequiredOption("--mailchimp-api-key")
+      }
+      self.mailchimpAPIKey = mailchimpAPIKey
+
+      guard let mailchimpListID = reader.read(Keys.mailchimpListID) else {
+        throw CommandError.missingRequiredOption("--mailchimp-list-id")
+      }
+      self.mailchimpListID = mailchimpListID
+
+      self.buttondownAPIKey = reader.read(Keys.buttondownAPIKey)
+      self.execute = reader.read(Keys.execute)
+    }
+
+    /// Builds the Buttondown client: an explicit `--buttondown-api-key` if
+    /// supplied, else the `BUTTONDOWN_API_KEY` environment fallback.
+    internal func makeButtondownClient() throws -> ButtondownClient {
+      if let buttondownAPIKey {
+        return try ButtondownClient(apiKey: buttondownAPIKey)
+      }
+      return try ButtondownClient.fromEnvironment()
+    }
+  }
+
+  private enum Keys {
+    static let mailchimpAPIKey = OptionalConfigKey<String>("mailchimp-api-key")
+    static let mailchimpListID = OptionalConfigKey<String>("mailchimp-list-id")
+    static let buttondownAPIKey = OptionalConfigKey<String>("buttondown-api-key")
+    static let execute = ConfigKey("execute", default: false)
+  }
+
+  /// Logs a `buttondown reconcile:` diagnostic line to stderr.
+  internal static func log(_ message: String) {
+    FileHandle.standardError.write(
+      Data("buttondown reconcile: \(message)\n".utf8)
+    )
+  }
+
+  public func execute() async throws {
+    let mailchimp = try MailchimpClient(apiKey: config.mailchimpAPIKey)
+    let buttondown = try config.makeButtondownClient()
+
+    Self.log("fetching Mailchimp sent campaigns for list \(config.mailchimpListID) …")
+    let campaigns = try await mailchimp.sentCampaigns(forListID: config.mailchimpListID)
+    Self.log("fetched \(campaigns.count) sent campaigns.")
+
+    Self.log("fetching current Buttondown emails …")
+    let emails = try await buttondown.listAllEmails()
+    Self.log("fetched \(emails.count) Buttondown emails.")
+
+    let numbered = Self.numberedCampaigns(from: campaigns)
+    let byIssueNo = Self.emailsByIssueNo(emails)
+    let plan = Self.buildPlan(numbered: numbered, buttondownByIssueNo: byIssueNo)
+
+    if config.execute {
+      try await runExecute(plan: plan, mailchimp: mailchimp, buttondown: buttondown)
+    } else {
+      try await printDryRun(
+        plan: plan,
+        campaignCount: campaigns.count,
+        emailCount: emails.count,
+        mailchimp: mailchimp
+      )
+    }
+  }
+
+  /// Fetches a campaign's archive HTML from Mailchimp and cleans it to Markdown,
+  /// which is the new/updated Buttondown body (Buttondown is Markdown-native).
+  private func cleanedBody(
+    forCampaignID campaignID: String,
+    using mailchimp: MailchimpClient
+  ) async throws -> String {
+    let html = try await mailchimp.archiveHTML(forCampaignID: campaignID)
+    return try Import.markdownGenerator.markdown(fromHTML: html)
+  }
+
+  /// Prints the reconciliation plan without performing any writes (the default).
+  ///
+  /// Shows totals, a per-issue CREATE/UPDATE line, whether issue #114 is in the
+  /// CREATE (backfill) set, and a short cleaned-body preview for the first couple
+  /// of CREATE issues so the HTML→Markdown cleanup can be eyeballed. Only the
+  /// preview issues have their archive HTML fetched, keeping the dry run a light
+  /// read that does not hammer Mailchimp's archive endpoint.
+  private func printDryRun(
+    plan: [PlanItem],
+    campaignCount: Int,
+    emailCount: Int,
+    mailchimp: MailchimpClient
+  ) async throws {
+    let creates = plan.filter { $0.action == .create }
+    let updates = plan.filter { $0.action == .update }
+
+    var lines: [String] = [
+      "",
+      "buttondown reconcile — DRY RUN (no writes; pass --execute to apply)",
+      "====================================================================",
+      "Mailchimp sent campaigns: \(campaignCount)",
+      "Buttondown emails:        \(emailCount)",
+      "Numbered newsletters:     \(plan.count)",
+      "  CREATE (backfill):      \(creates.count)",
+      "  UPDATE (clean body):    \(updates.count)",
+      "",
+      "Issue #114 in CREATE set: \(creates.contains { $0.issueNo == 114 } ? "YES" : "NO")",
+      "",
+      "Plan (by issue number):",
+    ]
+    for item in plan {
+      let tag = item.action == .create ? "CREATE" : "UPDATE"
+      lines.append("  \(tag)  #\(item.issueNo)  \(item.subject)")
+    }
+    print(lines.joined(separator: "\n"))
+
+    let previewItems = Array(creates.prefix(2))
+    guard !previewItems.isEmpty else {
+      return
+    }
+    print("\nCleaned-body preview (\(previewItems.count) CREATE issue(s)):")
+    for item in previewItems {
+      let body = try await cleanedBody(forCampaignID: item.campaignID, using: mailchimp)
+      print("\n--- #\(item.issueNo): \(item.subject) ---")
+      print(Self.previewSnippet(of: body))
+    }
+  }
+
+  /// A short, single-block preview of a cleaned body (first lines / characters).
+  private static func previewSnippet(of body: String) -> String {
+    let maxCharacters = 600
+    let trimmed = body.prefix(maxCharacters)
+    let suffix = body.count > maxCharacters ? "\n… (truncated)" : ""
+    return trimmed + suffix
+  }
+
+  /// Applies the plan to Buttondown: `createArchived` for backfills,
+  /// `updateEmail` for cleanups. Guarded behind `--execute`; **never** run live
+  /// as part of automated work — this path is for Leo's explicit invocation.
+  private func runExecute(
+    plan: [PlanItem],
+    mailchimp: MailchimpClient,
+    buttondown: ButtondownClient
+  ) async throws {
+    Self.log("--execute set: applying \(plan.count) actions to Buttondown …")
+    for item in plan {
+      let body = try await cleanedBody(forCampaignID: item.campaignID, using: mailchimp)
+      switch item.action {
+      case .create:
+        let email = try await buttondown.createArchived(
+          subject: item.subject,
+          body: body
+        )
+        Self.log("CREATED #\(item.issueNo) (\(email.id)): \(item.subject)")
+      case .update:
+        guard let id = item.existingEmailID else {
+          continue
+        }
+        let email = try await buttondown.updateEmail(id: id, body: body)
+        Self.log("UPDATED #\(item.issueNo) (\(email.id)): \(item.subject)")
+      }
+    }
+    Self.log("done.")
+  }
+}
+
+extension Buttondown {
+  /// ConfigKeyKit-based command for reconciling the Buttondown newsletter
+  /// archive against Mailchimp (issue #127).
+  ///
+  /// Registers under the two-token name `buttondown reconcile` and is dispatched
+  /// by ``CommandDispatcher``. Reads sent campaigns from Mailchimp (via
+  /// Spinetail) and the current emails from Buttondown, derives an issue number
+  /// for each, and builds a plan: CREATE (as an archived / never-sent email) any
+  /// issue missing from Buttondown, else UPDATE its body with the cleaned
+  /// Markdown. It **defaults to a dry run** that only prints the plan; live
+  /// Buttondown writes require an explicit `--execute` flag. It never touches
+  /// local `Content/newsletters/*.md`.
+  public struct ReconcileCommand: ConfigKeyKit.Command {
+    public static let commandName = "buttondown reconcile"
+    public static let abstract =
+      "Reconcile the Buttondown newsletter archive against Mailchimp (dry run by default)."
+    public static let helpText = """
+      OVERVIEW: Reconcile the Buttondown newsletter archive against Mailchimp.
+
+      Reads sent campaigns from Mailchimp (via Spinetail) and current emails from
+      Buttondown, then plans a CREATE (archived / never-sent) for each issue
+      missing from Buttondown and an UPDATE (cleaned body) for each issue already
+      present. Defaults to a DRY RUN that only prints the plan; local
+      Content/newsletters/*.md files are never touched.
+
+      USAGE: brightdigitwg buttondown reconcile --mailchimp-api-key <key> \
+      --mailchimp-list-id <id> [--buttondown-api-key <key>] [--execute]
+
+      OPTIONS:
+        --mailchimp-api-key <key>   Mailchimp API key. (required)
+        --mailchimp-list-id <id>    Mailchimp list ID. (required)
+        --buttondown-api-key <key>  Buttondown API key. Falls back to
+                                    BUTTONDOWN_API_KEY if omitted.
+        --execute                   Apply the plan to Buttondown. WITHOUT this
+                                    flag the command only prints the plan and
+                                    performs no writes.
+        -h, --help                  Show help information.
+
+      Each option may also be supplied via an uppercased, underscore-separated
+      environment variable (e.g. MAILCHIMP_API_KEY, BUTTONDOWN_API_KEY).
+      """
+
+    private let config: Config
+
+    public init(config: Config) {
+      self.config = config
+    }
+  }
+}

--- a/Sources/BrightDigitArgs/Config/Buttondown.swift
+++ b/Sources/BrightDigitArgs/Config/Buttondown.swift
@@ -1,0 +1,35 @@
+//
+//  Buttondown.swift
+//  BrightDigit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+/// Namespace for the two-token `buttondown …` commands (issue #127).
+///
+/// Caseless enum used purely as a namespace, analogous to ``Import``; the
+/// individual commands are added via extensions in their own files
+/// (``Buttondown/ReconcileCommand``).
+public enum Buttondown {}

--- a/Sources/BrightDigitArgs/Config/CommandDispatcher.swift
+++ b/Sources/BrightDigitArgs/Config/CommandDispatcher.swift
@@ -54,6 +54,7 @@ public enum CommandDispatcher {
     await registry.register(Import.PodcastCommand.self)
     await registry.register(Import.MailchimpCommand.self)
     await registry.register(Import.WordPressCommand.self)
+    await registry.register(Buttondown.ReconcileCommand.self)
 
     // argv after the executable name.
     let rawArguments = Array(CommandLine.arguments.dropFirst())

--- a/Tests/BrightDigitArgsTests/ButtondownReconcilePlanTests.swift
+++ b/Tests/BrightDigitArgsTests/ButtondownReconcilePlanTests.swift
@@ -1,0 +1,120 @@
+import ButtondownKit
+import Foundation
+import Spinetail
+import Testing
+
+@testable import BrightDigitArgs
+
+/// Unit tests for the pure planning logic behind `buttondown reconcile` (#127):
+/// issue-number derivation and CREATE-vs-UPDATE classification.
+internal struct ButtondownReconcilePlanTests {
+  private typealias Reconcile = Buttondown.ReconcileCommand
+
+  private static let day1 = Date(timeIntervalSince1970: 1_000_000)
+  private static let day1_5 = Date(timeIntervalSince1970: 1_500_000)
+  private static let day2 = Date(timeIntervalSince1970: 2_000_000)
+  private static let day3 = Date(timeIntervalSince1970: 3_000_000)
+
+  /// Builds a BrightDigit newsletter campaign (segment-tagged so it counts).
+  private func campaign(
+    id: String,
+    subject: String,
+    sendTime: Date,
+    segment: String? = "brightdigit-business"
+  ) -> MailchimpCampaign {
+    MailchimpCampaign(
+      id: id,
+      longArchiveURL: "https://archive.example/\(id)",
+      sendTime: sendTime,
+      subjectLine: subject,
+      title: subject,
+      previewText: nil,
+      segmentText: segment,
+      socialCardImageURL: nil
+    )
+  }
+
+  /// Builds a Buttondown email with the given id and subject.
+  private func email(id: String, subject: String) -> Email {
+    Email(
+      id: id,
+      subject: subject,
+      body: "body",
+      status: .imported,
+      creationDate: Self.day1,
+      modificationDate: Self.day1,
+      absoluteURL: "https://buttondown.example/\(id)",
+      description: "",
+      image: ""
+    )
+  }
+
+  @Test internal func numbersExplicitAndDateOrdersTrailingUnnumbered() {
+    let campaigns = [
+      // Trailing unnumbered (after the last numbered issue) → sequential 3.
+      campaign(id: "c4", subject: "Introducing swift-build", sendTime: Self.day3),
+      // Explicitly numbered.
+      campaign(id: "c1", subject: "BrightDigit Newsletter #1", sendTime: Self.day1),
+      campaign(id: "c2", subject: "BrightDigit #2", sendTime: Self.day2),
+      // Interior unnumbered (before the last numbered issue) → skipped.
+      campaign(id: "c3", subject: "Blog Updates", sendTime: Self.day1_5),
+      // Not a BrightDigit newsletter (no segment, no marker) → excluded.
+      campaign(id: "c5", subject: "Some other blast", sendTime: Self.day3, segment: nil),
+    ]
+
+    let numbered = Reconcile.numberedCampaigns(from: campaigns)
+
+    #expect(numbered.map(\.issueNo) == [1, 2, 3])
+    #expect(numbered.map(\.campaignID) == ["c1", "c2", "c4"])
+  }
+
+  @Test internal func indexesButtondownEmailsByParsedIssueNumber() {
+    let emails = [
+      email(id: "e98", subject: "BrightDigit Newsletter #98"),
+      email(id: "e114", subject: "BrightDigit #114"),
+      email(id: "eX", subject: "Welcome to the list!"),
+    ]
+
+    let byIssueNo = Reconcile.emailsByIssueNo(emails)
+
+    #expect(byIssueNo.count == 2)
+    #expect(byIssueNo[98]?.id == "e98")
+    #expect(byIssueNo[114]?.id == "e114")
+    #expect(byIssueNo[0] == nil)
+  }
+
+  @Test internal func classifiesMissingAsCreateAndPresentAsUpdate() {
+    let numbered = [
+      Reconcile.NumberedCampaign(
+        issueNo: 114, campaignID: "c114", subject: "BrightDigit #114", sendTime: Self.day3
+      ),
+      Reconcile.NumberedCampaign(
+        issueNo: 1, campaignID: "c1", subject: "BrightDigit Newsletter #1",
+        sendTime: Self.day1
+      ),
+      Reconcile.NumberedCampaign(
+        issueNo: 2, campaignID: "c2", subject: "BrightDigit #2", sendTime: Self.day2
+      ),
+    ]
+    // Only #2 already exists in Buttondown.
+    let byIssueNo = [2: email(id: "e2", subject: "BrightDigit #2")]
+
+    let plan = Reconcile.buildPlan(numbered: numbered, buttondownByIssueNo: byIssueNo)
+
+    // Sorted ascending by issue number.
+    #expect(plan.map(\.issueNo) == [1, 2, 114])
+
+    let creates = plan.filter { $0.action == .create }
+    let updates = plan.filter { $0.action == .update }
+    #expect(creates.map(\.issueNo) == [1, 114])
+    #expect(updates.map(\.issueNo) == [2])
+
+    // #114 must be backfilled (the known-missing issue).
+    #expect(creates.contains { $0.issueNo == 114 })
+
+    // The UPDATE carries the existing Buttondown email id; CREATEs do not.
+    let update = try! #require(updates.first)
+    #expect(update.existingEmailID == "e2")
+    #expect(creates.allSatisfy { $0.existingEmailID == nil })
+  }
+}


### PR DESCRIPTION
Closes #127 (Track A archive one-shot). Targets `phase-05`. **Draft** — Leo reviews & merges; `--execute` has **not** been run against the live Buttondown account.

## What

Self-contained reconciliation of the Buttondown newsletter archive against Mailchimp's sent campaigns. Does **not** touch `Content/newsletters/*.md` and does **not** use the outbound orchestrator.

### C1 — `updateEmail` in ButtondownKit (commit `e62e80c1`)
- `PATCH /emails/{id}` via new `EmailUpdating` capability protocol; normalized the vendored `openapi.json` so `EmailUpdateInput` exposes optional `body`/`subject`/`description`/`status` (the generator otherwise drops `anyOf:[X, null]` fields), regenerated `Client.swift`/`Types.swift`, added `- update_email` to the generator filter.
- 3 Swift Testing cases + `email-updated.json` fixture.

### C2 — `createArchived` + `buttondown reconcile` (commit `c4b4bd87`)
- **`createArchived(subject:body:)`** — `POST /emails` with `status: imported` + `archival_mode: enabled`: a backfilled historical issue appears in the public archive but is never delivered. 3 tests + fixture.
- **`buttondown reconcile`** (ConfigKeyKit command) — reads Mailchimp sent campaigns (Spinetail) + current Buttondown emails, derives an issue number for each, and plans **CREATE** (backfill missing, incl. #114) vs **UPDATE** (clean body of existing).
  - **Defaults to a DRY RUN** that only prints the plan. Live writes require an explicit `--execute`.
  - Pure planning logic (`numberedCampaigns` / `emailsByIssueNo` / `buildPlan`) factored into `+Plan.swift`, covered by 3 Swift Testing cases.
  - Reuses `Import.MailchimpCommand`'s issue-number parsing so reconcile and import agree on numbering.

## Wiring
`ButtondownKit` added to `BrightDigitArgs` + its test target in `Package.swift`; command registered in `CommandDispatcher`.

## Verification
- `swift build` clean; ButtondownKit **19/19** tests pass (incl. 3 archiving + 3 updating); `ButtondownReconcilePlanTests` **3/3** pass.
- **Not yet run:** `buttondown reconcile --execute` against the live account, and the dry-run against live keys (needs `BUTTONDOWN_API_KEY` + `MAILCHIMP_API_KEY`) — left to Leo.

## Notes for review
- Shares two files with #122 (`Package.swift`, `CommandDispatcher.swift`) — expect trivial conflicts when merged sequentially.
- ButtondownKit is a git-subrepo; `git subrepo push` is at Leo's discretion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)